### PR TITLE
Span Batch Tx Encoding

### DIFF
--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -51,6 +51,9 @@ const (
 // adjust this for trying different tx encoding schemes
 var BatchV2TxsType = BatchV2TxsV3Type
 
+// TODO: fix hardcoded chainID
+var ChainID = big.NewInt(1337)
+
 type BatchV1 struct {
 	ParentHash common.Hash  // parent L2 block hash
 	EpochNum   rollup.Epoch // aka l1 num
@@ -180,7 +183,7 @@ func (b *BatchV2) DecodePayload(r *bytes.Reader) error {
 		b.Txs = &BatchV2TxsV3{}
 		b.Txs.(*BatchV2TxsV3).TotalBlockTxCount = totalBlockTxCount
 		// TODO: fix hardcoded chainID
-		b.Txs.(*BatchV2TxsV3).ChainID = big.NewInt(1337)
+		b.Txs.(*BatchV2TxsV3).ChainID = ChainID
 	default:
 		return fmt.Errorf("invalid BatchV2TxsType: %d", BatchV2TxsV2Type)
 	}

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -61,6 +61,7 @@ type BatchV2Prefix struct {
 type BatchV2Txs interface {
 	Encode(w io.Writer) error
 	Decode(r *bytes.Reader) error
+	// FullTxs returns list of raw full transactions from BatchV2Txs
 	FullTxs() ([][]byte, error)
 }
 

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -176,8 +176,13 @@ func (b *BatchV2) DecodePayload(r *bytes.Reader) error {
 		b.Txs.(*BatchV2TxsV1).TotalBlockTxCount = totalBlockTxCount
 	case BatchV2TxsV2Type:
 		b.Txs = &BatchV2TxsV2{}
+	case BatchV2TxsV3Type:
+		b.Txs = &BatchV2TxsV3{}
+		b.Txs.(*BatchV2TxsV3).TotalBlockTxCount = totalBlockTxCount
+		// TODO: fix hardcoded chainID
+		b.Txs.(*BatchV2TxsV3).ChainID = big.NewInt(1337)
 	default:
-		return fmt.Errorf("invalid BatchV2TxsV2Type: %d", BatchV2TxsV2Type)
+		return fmt.Errorf("invalid BatchV2TxsType: %d", BatchV2TxsV2Type)
 	}
 	b.Txs.Decode(r)
 	b.BlockCount = blockCount
@@ -407,6 +412,8 @@ func (b *BatchV2) MergeBatchV1s(batchV1s []BatchV1, originChangedBit uint, genes
 		batchV2Txs, err = NewBatchV2TxsV1(txs)
 	case BatchV2TxsV2Type:
 		batchV2Txs, err = NewBatchV2TxsV2(txs)
+	case BatchV2TxsV3Type:
+		batchV2Txs, err = NewBatchV2TxsV3(txs)
 	default:
 		return fmt.Errorf("invalid BatchV2TxsType: %d", BatchV2TxsType)
 	}
@@ -445,6 +452,7 @@ func (b *BatchV2) SplitBatchV2(fetchL1Block func(uint64) (*types.Block, error), 
 			}
 		}
 	}
+
 	txs, err := b.Txs.FullTxs()
 	if err != nil {
 		return nil, err

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -45,10 +45,11 @@ const (
 const (
 	BatchV2TxsV1Type = iota
 	BatchV2TxsV2Type
+	BatchV2TxsV3Type
 )
 
 // adjust this for trying different tx encoding schemes
-const BatchV2TxsType = BatchV2TxsV1Type
+var BatchV2TxsType = BatchV2TxsV3Type
 
 type BatchV1 struct {
 	ParentHash common.Hash  // parent L2 block hash

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -159,7 +159,7 @@ func (b *BatchV2) DecodePayload(r *bytes.Reader) error {
 		blockTxCounts[i] = blockTxCount
 		totalBlockTxCount += blockTxCount
 	}
-
+	// abstract out by BatchV2Txs type
 	b.Txs = &BatchV2TxsV1{}
 	b.Txs.(*BatchV2TxsV1).TotalBlockTxCount = totalBlockTxCount
 	b.Txs.Decode(r)
@@ -383,6 +383,7 @@ func (b *BatchV2) MergeBatchV1s(batchV1s []BatchV1, originChangedBit uint, genes
 		}
 	}
 	b.BlockTxCounts = blockTxCounts
+	// abstract out by BatchV2Txs type
 	batchV2Txs, err := NewBatchV2TxsV1(txs)
 	if err != nil {
 		return err

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -175,16 +175,11 @@ func TestBatchV2Merge(t *testing.T) {
 		for txIdx := 0; txIdx < txCount; txIdx++ {
 			switch BatchV2TxsType {
 			case BatchV2TxsV1Type:
-				txDataHeader := batchV2.Txs.(*BatchV2TxsV1).TxDataHeaders[cnt]
-				txData := batchV2.Txs.(*BatchV2TxsV1).TxDatas[cnt]
-				assert.True(t, int(txDataHeader) == len(txData))
+				// nothing to validate
 			case BatchV2TxsV2Type:
 				rawTx := batchV2.Txs.(*BatchV2TxsV2).TxDatas[cnt]
 				assert.True(t, bytes.Equal(rawTx, batchV1s[i].Transactions[txIdx]))
 			case BatchV2TxsV3Type:
-				txDataHeader := batchV2.Txs.(*BatchV2TxsV3).TxDataHeaders[cnt]
-				txData := batchV2.Txs.(*BatchV2TxsV3).TxDatas[cnt]
-				assert.True(t, int(txDataHeader) == len(txData))
 				for _, txTo := range batchV2.Txs.(*BatchV2TxsV3).TxTos {
 					assert.True(t, len(txTo) == common.AddressLength)
 				}
@@ -269,16 +264,11 @@ func TestBatchV2Split(t *testing.T) {
 		for txIdx := 0; txIdx < txCount; txIdx++ {
 			switch BatchV2TxsType {
 			case BatchV2TxsV1Type:
-				txDataHeader := batchV2.Txs.(*BatchV2TxsV1).TxDataHeaders[cnt]
-				txData := batchV2.Txs.(*BatchV2TxsV1).TxDatas[cnt]
-				assert.True(t, int(txDataHeader) == len(txData))
+				// nothing to validate
 			case BatchV2TxsV2Type:
 				rawTx := batchV2.Txs.(*BatchV2TxsV2).TxDatas[cnt]
 				assert.True(t, bytes.Equal(rawTx, batchV1s[i].Transactions[txIdx]))
 			case BatchV2TxsV3Type:
-				txDataHeader := batchV2.Txs.(*BatchV2TxsV3).TxDataHeaders[cnt]
-				txData := batchV2.Txs.(*BatchV2TxsV3).TxDatas[cnt]
-				assert.True(t, int(txDataHeader) == len(txData))
 				for _, txTo := range batchV2.Txs.(*BatchV2TxsV3).TxTos {
 					assert.True(t, len(txTo) == common.AddressLength)
 				}

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -39,8 +39,7 @@ func RandomBatchV2(rng *rand.Rand) *BatchData {
 	var txs [][]byte
 	// TODO: fix hardcoded chainID
 	// chainID := big.NewInt(rng.Int63n(1000))
-	chainID := big.NewInt(1337)
-	signer := types.NewLondonSigner(chainID)
+	signer := types.NewLondonSigner(ChainID)
 	for i := 0; i < int(totalblockTxCount); i++ {
 		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
 		rawTx, err := tx.MarshalBinary()

--- a/op-node/rollup/derive/batch_tx_test.go
+++ b/op-node/rollup/derive/batch_tx_test.go
@@ -1,1 +1,0 @@
-package derive

--- a/op-node/rollup/derive/batch_tx_v1.go
+++ b/op-node/rollup/derive/batch_tx_v1.go
@@ -60,8 +60,8 @@ func (btx *BatchV2TxsV1) Encode(w io.Writer) error {
 	return nil
 }
 
-// DecodeTxData reads raw RLP tx data from reader
-func DecodeTxData(r *bytes.Reader) ([]byte, error) {
+// ReadTxData reads raw RLP tx data from reader
+func ReadTxData(r *bytes.Reader) ([]byte, error) {
 	var txData []byte
 	offset, err := r.Seek(0, io.SeekCurrent)
 	if err != nil {
@@ -114,7 +114,7 @@ func (btx *BatchV2TxsV1) Decode(r *bytes.Reader) error {
 	// Do not need txDataHeader because RLP byte stream already includes length info
 	txDatas := make([]hexutil.Bytes, len(txDataHeaders))
 	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
-		txData, err := DecodeTxData(r)
+		txData, err := ReadTxData(r)
 		if err != nil {
 			return err
 		}

--- a/op-node/rollup/derive/batch_tx_v1.go
+++ b/op-node/rollup/derive/batch_tx_v1.go
@@ -60,8 +60,8 @@ func (btx *BatchV2TxsV1) Encode(w io.Writer) error {
 	return nil
 }
 
-// decodeTxData reads raw RLP tx data from reader
-func decodeTxData(r *bytes.Reader) ([]byte, error) {
+// DecodeTxData reads raw RLP tx data from reader
+func DecodeTxData(r *bytes.Reader) ([]byte, error) {
 	var txData []byte
 	offset, err := r.Seek(0, io.SeekCurrent)
 	if err != nil {
@@ -111,9 +111,10 @@ func (btx *BatchV2TxsV1) Decode(r *bytes.Reader) error {
 		txDataHeaders[i] = txDataHeader
 	}
 
+	// Do not need txDataHeader because RLP byte stream already includes length info
 	txDatas := make([]hexutil.Bytes, len(txDataHeaders))
 	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
-		txData, err := decodeTxData(r)
+		txData, err := DecodeTxData(r)
 		if err != nil {
 			return err
 		}

--- a/op-node/rollup/derive/batch_tx_v1.go
+++ b/op-node/rollup/derive/batch_tx_v1.go
@@ -155,7 +155,6 @@ func (btx *BatchV2TxsV1) FullTxs() ([][]byte, error) {
 
 func NewBatchV2TxsV1(txs [][]byte) (*BatchV2TxsV1, error) {
 	totalBlockTxCount := uint64(len(txs))
-	var txDataHeaders []uint64
 	var txDatas []hexutil.Bytes
 	var txSigs []BatchV2Signature
 	for idx := 0; idx < int(totalBlockTxCount); idx++ {
@@ -179,8 +178,6 @@ func NewBatchV2TxsV1(txs [][]byte) (*BatchV2TxsV1, error) {
 		if err != nil {
 			return nil, err
 		}
-		txDataHeader := uint64(len(txData))
-		txDataHeaders = append(txDataHeaders, txDataHeader)
 		txDatas = append(txDatas, txData)
 	}
 	return &BatchV2TxsV1{

--- a/op-node/rollup/derive/batch_tx_v1.go
+++ b/op-node/rollup/derive/batch_tx_v1.go
@@ -193,12 +193,7 @@ func NewBatchV2TxsV1(txs [][]byte) (*BatchV2TxsV1, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		txData, err := batchV2TxV1.MarshalBinary()
-
-		// fmt.Println(fmt.Sprintf("%x", len(txData)))
-		// fmt.Println(hex.EncodeToString(txData))
-
 		if err != nil {
 			return nil, err
 		}

--- a/op-node/rollup/derive/batch_tx_v1.go
+++ b/op-node/rollup/derive/batch_tx_v1.go
@@ -60,6 +60,7 @@ func (btx *BatchV2TxsV1) Encode(w io.Writer) error {
 	return nil
 }
 
+// decodeTxData reads raw RLP tx data from reader
 func decodeTxData(r *bytes.Reader) ([]byte, error) {
 	var txData []byte
 	offset, err := r.Seek(0, io.SeekCurrent)
@@ -111,7 +112,6 @@ func (btx *BatchV2TxsV1) Decode(r *bytes.Reader) error {
 	}
 
 	txDatas := make([]hexutil.Bytes, len(txDataHeaders))
-	// manual RLP decoding
 	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
 		txData, err := decodeTxData(r)
 		if err != nil {

--- a/op-node/rollup/derive/batch_tx_v1.go
+++ b/op-node/rollup/derive/batch_tx_v1.go
@@ -22,10 +22,12 @@ type BatchV2Signature struct {
 }
 
 type BatchV2TxsV1 struct {
+	// below single field must be manually set
 	TotalBlockTxCount uint64
-	TxDataHeaders     []uint64
-	TxDatas           []hexutil.Bytes
-	TxSigs            []BatchV2Signature
+
+	TxDataHeaders []uint64
+	TxDatas       []hexutil.Bytes
+	TxSigs        []BatchV2Signature
 }
 
 func (btx *BatchV2TxsV1) Encode(w io.Writer) error {

--- a/op-node/rollup/derive/batch_tx_v2.go
+++ b/op-node/rollup/derive/batch_tx_v2.go
@@ -1,0 +1,48 @@
+package derive
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type BatchV2TxsV2 struct {
+	TxDatas [][]byte
+}
+
+func (btx *BatchV2TxsV2) Encode(w io.Writer) error {
+	return rlp.Encode(w, btx.TxDatas)
+}
+
+func (btx *BatchV2TxsV2) Decode(r *bytes.Reader) error {
+	return rlp.Decode(r, &btx.TxDatas)
+}
+
+// checkTxValid checks rawTx by unmarshaling
+func checkTxValid(txs *[][]byte) error {
+	for _, rawTx := range *txs {
+		var tx types.Transaction
+		if err := tx.UnmarshalBinary(rawTx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (btx BatchV2TxsV2) FullTxs() ([][]byte, error) {
+	if err := checkTxValid(&btx.TxDatas); err != nil {
+		return nil, err
+	}
+	return btx.TxDatas, nil
+}
+
+func NewBatchV2TxsV2(txs [][]byte) (*BatchV2TxsV2, error) {
+	if err := checkTxValid(&txs); err != nil {
+		return nil, err
+	}
+	return &BatchV2TxsV2{
+		TxDatas: txs,
+	}, nil
+}

--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -200,11 +200,11 @@ func (btx *BatchV2TxsV3) Decode(r *bytes.Reader) error {
 		txDataHeaders[i] = txDataHeader
 	}
 	txDatas := make([]hexutil.Bytes, len(txDataHeaders))
-	for i, txDataHeader := range txDataHeaders {
-		txData := make([]byte, txDataHeader)
-		_, err := io.ReadFull(r, txData)
+	// Do not need txDataHeader because RLP byte stream already includes length info
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
+		txData, err := ReadTxData(r)
 		if err != nil {
-			return fmt.Errorf("failed to tx data: %w", err)
+			return err
 		}
 		txDatas[i] = txData
 	}

--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -280,7 +280,7 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 	}
 	return &BatchV2TxsV3{
 		TotalBlockTxCount:    totalBlockTxCount,
-		ChainID:              big.NewInt(1337), // TODO: fix hardcoded chainID
+		ChainID:              ChainID, // TODO: fix hardcoded chainID
 		ContractCreationBits: contractCreationBits,
 		TxSigs:               txSigs,
 		TxNonces:             txNonces,

--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -21,6 +21,7 @@ type BatchV2TxsV3 struct {
 	ChainID           *big.Int
 
 	ContractCreationBits *big.Int
+	YParityBits          *big.Int
 	TxSigs               []BatchV2Signature
 	TxNonces             []uint64
 	TxGases              []uint64
@@ -78,17 +79,75 @@ func (btx *BatchV2TxsV3) ContractCreationCount() (uint64, error) {
 	return result, nil
 }
 
+func (btx *BatchV2TxsV3) EncodeYParityBits() []byte {
+	yParityBitBufferLen := btx.TotalBlockTxCount / 8
+	if btx.TotalBlockTxCount%8 != 0 {
+		yParityBitBufferLen++
+	}
+	yParityBitBuffer := make([]byte, yParityBitBufferLen)
+	for i := 0; i < int(btx.TotalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.TotalBlockTxCount) {
+			end = int(btx.TotalBlockTxCount)
+		}
+		var bits uint = 0
+		for j := i; j < end; j++ {
+			bits |= btx.YParityBits.Bit(j) << (j - i)
+		}
+		yParityBitBuffer[i/8] = byte(bits)
+	}
+	return yParityBitBuffer
+}
+
+func (btx *BatchV2TxsV3) DecodeYParityBits(yParityBitBuffer []byte) {
+	yParityBits := new(big.Int)
+	for i := 0; i < int(btx.TotalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.TotalBlockTxCount) {
+			end = int(btx.TotalBlockTxCount)
+		}
+		bits := yParityBitBuffer[i/8]
+		for j := i; j < end; j++ {
+			bit := uint((bits >> (j - i)) & 1)
+			yParityBits.SetBit(yParityBits, j, bit)
+		}
+	}
+	btx.YParityBits = yParityBits
+}
+
+func (btx *BatchV2TxsV3) RecoverV(txTypes []int) {
+	if len(txTypes) != len(btx.TxSigs) {
+		panic("tx type length and tx sigs length mismatch")
+	}
+	for idx, txType := range txTypes {
+		bit := uint64(btx.YParityBits.Bit(idx))
+		var v uint64
+		switch txType {
+		case types.LegacyTxType:
+			// EIP155
+			v = btx.ChainID.Uint64()*2 + 35 + bit
+		case types.AccessListTxType:
+			v = bit
+		case types.DynamicFeeTxType:
+			v = bit
+		default:
+			panic(fmt.Sprintf("invalid tx type: %d", txType))
+		}
+		btx.TxSigs[idx].V = v
+	}
+}
+
 func (btx *BatchV2TxsV3) Encode(w io.Writer) error {
 	var buf [binary.MaxVarintLen64]byte
 	contractCreationBitBuffer := btx.EncodeContractCreationBits()
 	if _, err := w.Write(contractCreationBitBuffer); err != nil {
 		return fmt.Errorf("cannot write contract creation bits: %w", err)
 	}
+	yParityBitBuffer := btx.EncodeYParityBits()
+	if _, err := w.Write(yParityBitBuffer); err != nil {
+		return fmt.Errorf("cannot write y parity bits: %w", err)
+	}
 	for _, txSig := range btx.TxSigs {
-		n := binary.PutUvarint(buf[:], txSig.V)
-		if _, err := w.Write(buf[:n]); err != nil {
-			return fmt.Errorf("cannot write tx sig v: %w", err)
-		}
 		rBuf := txSig.R.Bytes32()
 		if _, err := w.Write(rBuf[:]); err != nil {
 			return fmt.Errorf("cannot write tx sig r: %w", err)
@@ -133,15 +192,19 @@ func (btx *BatchV2TxsV3) Decode(r *bytes.Reader) error {
 	if err != nil {
 		return fmt.Errorf("failed to read contract creation bits: %w", err)
 	}
+	yParityBitBufferLen := btx.TotalBlockTxCount / 8
+	if btx.TotalBlockTxCount%8 != 0 {
+		yParityBitBufferLen++
+	}
+	yParityBitBuffer := make([]byte, yParityBitBufferLen)
+	_, err = io.ReadFull(r, yParityBitBuffer)
+	if err != nil {
+		return fmt.Errorf("failed to read y parity bits: %w", err)
+	}
 	txSigs := make([]BatchV2Signature, btx.TotalBlockTxCount)
 	var sigBuffer [32]byte
 	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
 		var txSig BatchV2Signature
-		v, err := binary.ReadUvarint(r)
-		if err != nil {
-			return fmt.Errorf("failed to read tx sig v: %w", err)
-		}
-		txSig.V = v
 		_, err = io.ReadFull(r, sigBuffer[:])
 		if err != nil {
 			return fmt.Errorf("failed to read tx sig r: %w", err)
@@ -185,15 +248,19 @@ func (btx *BatchV2TxsV3) Decode(r *bytes.Reader) error {
 		txTos = append(txTos, common.BytesToAddress(txToBuffer))
 	}
 	txDatas := make([]hexutil.Bytes, btx.TotalBlockTxCount)
+	txTypes := make([]int, btx.TotalBlockTxCount)
 	// Do not need txDataHeader because RLP byte stream already includes length info
 	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
-		txData, err := ReadTxData(r)
+		txData, txType, err := ReadTxData(r)
 		if err != nil {
 			return err
 		}
 		txDatas[i] = txData
+		txTypes[i] = txType
 	}
 	btx.TxSigs = txSigs
+	btx.DecodeYParityBits(yParityBitBuffer)
+	btx.RecoverV(txTypes)
 	btx.TxNonces = txNonces
 	btx.TxGases = txGases
 	btx.TxTos = txTos
@@ -244,6 +311,7 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 	var txGases []uint64
 	var txDatas []hexutil.Bytes
 	contractCreationBits := new(big.Int)
+	yParityBits := new(big.Int)
 	for idx := 0; idx < int(totalBlockTxCount); idx++ {
 		var tx types.Transaction
 		if err := tx.UnmarshalBinary(txs[idx]); err != nil {
@@ -263,6 +331,20 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 			contractCreationBit = uint(0)
 		}
 		contractCreationBits.SetBit(contractCreationBits, idx, contractCreationBit)
+		var yParityBit uint
+		switch tx.Type() {
+		case types.LegacyTxType:
+			// EIP155: v = 2 * chainID + 35 + yParity
+			// v - 35 = yParity (mod 2)
+			yParityBit = uint((txSig.V - 35) & 1)
+		case types.AccessListTxType:
+			yParityBit = uint(txSig.V)
+		case types.DynamicFeeTxType:
+			yParityBit = uint(txSig.V)
+		default:
+			panic(fmt.Sprintf("invalid tx type: %d", tx.Type()))
+		}
+		yParityBits.SetBit(yParityBits, idx, yParityBit)
 		txNonces = append(txNonces, tx.Nonce())
 		txGases = append(txGases, tx.Gas())
 		batchV2TxV3, err := NewBatchV2TxV3(tx)
@@ -279,6 +361,7 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 		TotalBlockTxCount:    totalBlockTxCount,
 		ChainID:              ChainID, // TODO: fix hardcoded chainID
 		ContractCreationBits: contractCreationBits,
+		YParityBits:          yParityBits,
 		TxSigs:               txSigs,
 		TxNonces:             txNonces,
 		TxGases:              txGases,

--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -242,7 +242,6 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 	var txTos []common.Address
 	var txNonces []uint64
 	var txGases []uint64
-	var txDataHeaders []uint64
 	var txDatas []hexutil.Bytes
 	contractCreationBits := new(big.Int)
 	for idx := 0; idx < int(totalBlockTxCount); idx++ {
@@ -274,8 +273,6 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 		if err != nil {
 			return nil, err
 		}
-		txDataHeader := uint64(len(txData))
-		txDataHeaders = append(txDataHeaders, txDataHeader)
 		txDatas = append(txDatas, txData)
 	}
 	return &BatchV2TxsV3{

--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -1,0 +1,25 @@
+package derive
+
+import (
+	"bytes"
+	"io"
+)
+
+type BatchV2TxsV3 struct {
+}
+
+func (btx *BatchV2TxsV3) Encode(w io.Writer) error {
+	panic("not implemented")
+}
+
+func (btx *BatchV2TxsV3) Decode(r *bytes.Reader) error {
+	panic("not implemented")
+}
+
+func (btx BatchV2TxsV3) FullTxs() ([][]byte, error) {
+	panic("not implemented")
+}
+
+func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
+	panic("not implemented")
+}

--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -2,24 +2,530 @@ package derive
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/holiman/uint256"
 )
 
 type BatchV2TxsV3 struct {
+	// these two fields must be manually set
+	TotalBlockTxCount uint64
+	ChainID           *big.Int
+
+	ContractCreationBits *big.Int
+	TxSigs               []BatchV2Signature
+	TxNonces             []uint64
+	TxGases              []uint64
+	TxTos                []common.Address
+	TxDataHeaders        []uint64
+	TxDatas              []hexutil.Bytes
+}
+
+func (btx *BatchV2TxsV3) EncodeContractCreationBits() []byte {
+	contractCreationBitBufferLen := btx.TotalBlockTxCount / 8
+	if btx.TotalBlockTxCount%8 != 0 {
+		contractCreationBitBufferLen++
+	}
+	contractCreationBitBuffer := make([]byte, contractCreationBitBufferLen)
+	for i := 0; i < int(btx.TotalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.TotalBlockTxCount) {
+			end = int(btx.TotalBlockTxCount)
+		}
+		var bits uint = 0
+		for j := i; j < end; j++ {
+			bits |= btx.ContractCreationBits.Bit(j) << (j - i)
+		}
+		contractCreationBitBuffer[i/8] = byte(bits)
+	}
+	return contractCreationBitBuffer
+}
+
+func (btx *BatchV2TxsV3) DecodeContractCreationBits(contractCreationBitBuffer []byte) {
+	contractCreationBits := new(big.Int)
+	for i := 0; i < int(btx.TotalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.TotalBlockTxCount) {
+			end = int(btx.TotalBlockTxCount)
+		}
+		bits := contractCreationBitBuffer[i/8]
+		for j := i; j < end; j++ {
+			bit := uint((bits >> (j - i)) & 1)
+			contractCreationBits.SetBit(contractCreationBits, j, bit)
+		}
+	}
+	btx.ContractCreationBits = contractCreationBits
+}
+
+func (btx *BatchV2TxsV3) ContractCreationCount() uint64 {
+	var result uint64 = 0
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
+		bit := btx.ContractCreationBits.Bit(i)
+		if bit == 1 {
+			result++
+		}
+	}
+	return result
 }
 
 func (btx *BatchV2TxsV3) Encode(w io.Writer) error {
-	panic("not implemented")
+	var buf [binary.MaxVarintLen64]byte
+	contractCreationBitBuffer := btx.EncodeContractCreationBits()
+	if _, err := w.Write(contractCreationBitBuffer); err != nil {
+		return fmt.Errorf("cannot write contract creation bits: %w", err)
+	}
+	for _, txSig := range btx.TxSigs {
+		n := binary.PutUvarint(buf[:], txSig.V)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write tx sig v: %w", err)
+		}
+		rBuf := txSig.R.Bytes32()
+		if _, err := w.Write(rBuf[:]); err != nil {
+			return fmt.Errorf("cannot write tx sig r: %w", err)
+		}
+		sBuf := txSig.S.Bytes32()
+		if _, err := w.Write(sBuf[:]); err != nil {
+			return fmt.Errorf("cannot write tx sig s: %w", err)
+		}
+	}
+	for _, txNonce := range btx.TxNonces {
+		n := binary.PutUvarint(buf[:], txNonce)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write tx nonce: %w", err)
+		}
+	}
+	for _, txGas := range btx.TxGases {
+		n := binary.PutUvarint(buf[:], txGas)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write tx gas: %w", err)
+		}
+	}
+	for _, txTo := range btx.TxTos {
+		if _, err := w.Write(txTo.Bytes()); err != nil {
+			return fmt.Errorf("cannot write tx to address: %w", err)
+		}
+	}
+	for _, txDataHeader := range btx.TxDataHeaders {
+		n := binary.PutUvarint(buf[:], txDataHeader)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write tx data header: %w", err)
+		}
+	}
+	for _, txData := range btx.TxDatas {
+		if _, err := w.Write(txData); err != nil {
+			return fmt.Errorf("cannot write tx data: %w", err)
+		}
+	}
+	return nil
 }
 
 func (btx *BatchV2TxsV3) Decode(r *bytes.Reader) error {
-	panic("not implemented")
+	contractCreationBitBufferLen := btx.TotalBlockTxCount / 8
+	if btx.TotalBlockTxCount%8 != 0 {
+		contractCreationBitBufferLen++
+	}
+	contractCreationBitBuffer := make([]byte, contractCreationBitBufferLen)
+	_, err := io.ReadFull(r, contractCreationBitBuffer)
+	if err != nil {
+		return fmt.Errorf("failed to read contract creation bits: %w", err)
+	}
+	txSigs := make([]BatchV2Signature, btx.TotalBlockTxCount)
+	var sigBuffer [32]byte
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
+		var txSig BatchV2Signature
+		v, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read tx sig v: %w", err)
+		}
+		txSig.V = v
+		_, err = io.ReadFull(r, sigBuffer[:])
+		if err != nil {
+			return fmt.Errorf("failed to read tx sig r: %w", err)
+		}
+		txSig.R, _ = uint256.FromBig(new(big.Int).SetBytes(sigBuffer[:]))
+		_, err = io.ReadFull(r, sigBuffer[:])
+		if err != nil {
+			return fmt.Errorf("failed to read tx sig s: %w", err)
+		}
+		txSig.S, _ = uint256.FromBig(new(big.Int).SetBytes(sigBuffer[:]))
+		txSigs[i] = txSig
+	}
+	txNonces := make([]uint64, btx.TotalBlockTxCount)
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
+		txNonce, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read tx nonce: %w", err)
+		}
+		txNonces[i] = txNonce
+	}
+	txGases := make([]uint64, btx.TotalBlockTxCount)
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
+		txGas, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read tx gas: %w", err)
+		}
+		txGases[i] = txGas
+	}
+	var txTos []common.Address
+	txToBuffer := make([]byte, common.AddressLength)
+	for i := 0; i < int(btx.TotalBlockTxCount-btx.ContractCreationCount()); i++ {
+		_, err := io.ReadFull(r, txToBuffer)
+		if err != nil {
+			return fmt.Errorf("failed to read tx to address: %w", err)
+		}
+		txTos = append(txTos, common.BytesToAddress(txToBuffer))
+	}
+	txDataHeaders := make([]uint64, btx.TotalBlockTxCount)
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
+		txDataHeader, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read tx data header: %w", err)
+		}
+		txDataHeaders[i] = txDataHeader
+	}
+	txDatas := make([]hexutil.Bytes, len(txDataHeaders))
+	for i, txDataHeader := range txDataHeaders {
+		txData := make([]byte, txDataHeader)
+		_, err := io.ReadFull(r, txData)
+		if err != nil {
+			return fmt.Errorf("failed to tx data: %w", err)
+		}
+		txDatas[i] = txData
+	}
+	btx.DecodeContractCreationBits(contractCreationBitBuffer)
+	btx.TxSigs = txSigs
+	btx.TxNonces = txNonces
+	btx.TxGases = txGases
+	btx.TxTos = txTos
+	btx.TxDataHeaders = txDataHeaders
+	btx.TxDatas = txDatas
+	return nil
 }
 
 func (btx BatchV2TxsV3) FullTxs() ([][]byte, error) {
-	panic("not implemented")
+	var txs [][]byte
+	toIdx := 0
+	for idx := 0; idx < int(btx.TotalBlockTxCount); idx++ {
+		var batchV2TxV3 BatchV2TxV3
+		if err := batchV2TxV3.UnmarshalBinary(btx.TxDatas[idx]); err != nil {
+			return nil, err
+		}
+		nonce := btx.TxNonces[idx]
+		gas := btx.TxGases[idx]
+		var to *common.Address = nil
+		bit := btx.ContractCreationBits.Bit(idx)
+		if bit == 0 {
+			if len(btx.TxTos) <= toIdx {
+				return nil, errors.New("tx to not enough")
+			}
+			to = &btx.TxTos[toIdx]
+			toIdx++
+		}
+		v := new(big.Int).SetUint64(btx.TxSigs[idx].V)
+		r := btx.TxSigs[idx].R.ToBig()
+		s := btx.TxSigs[idx].S.ToBig()
+		tx, err := batchV2TxV3.ConvertToFullTx(nonce, gas, to, btx.ChainID, v, r, s)
+		if err != nil {
+			return nil, err
+		}
+		encodedTx, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, encodedTx)
+	}
+	return txs, nil
 }
 
 func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
-	panic("not implemented")
+	totalBlockTxCount := uint64(len(txs))
+	var txSigs []BatchV2Signature
+	var txTos []common.Address
+	var txNonces []uint64
+	var txGases []uint64
+	var txDataHeaders []uint64
+	var txDatas []hexutil.Bytes
+	contractCreationBits := new(big.Int)
+	for idx := 0; idx < int(totalBlockTxCount); idx++ {
+		var tx types.Transaction
+		if err := tx.UnmarshalBinary(txs[idx]); err != nil {
+			return nil, errors.New("failed to decode tx")
+		}
+		var txSig BatchV2Signature
+		v, r, s := tx.RawSignatureValues()
+		R, _ := uint256.FromBig(r)
+		S, _ := uint256.FromBig(s)
+		txSig.V = v.Uint64()
+		txSig.R = R
+		txSig.S = S
+		txSigs = append(txSigs, txSig)
+		contractCreationBit := uint(1)
+		if tx.To() != nil {
+			txTos = append(txTos, *tx.To())
+			contractCreationBit = uint(0)
+		}
+		contractCreationBits.SetBit(contractCreationBits, idx, contractCreationBit)
+		txNonces = append(txNonces, tx.Nonce())
+		txGases = append(txGases, tx.Gas())
+		batchV2TxV3, err := NewBatchV2TxV3(tx)
+		if err != nil {
+			return nil, err
+		}
+		txData, err := batchV2TxV3.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		txDataHeader := uint64(len(txData))
+		txDataHeaders = append(txDataHeaders, txDataHeader)
+		txDatas = append(txDatas, txData)
+	}
+	return &BatchV2TxsV3{
+		TotalBlockTxCount:    totalBlockTxCount,
+		ContractCreationBits: contractCreationBits,
+		TxSigs:               txSigs,
+		TxNonces:             txNonces,
+		TxGases:              txGases,
+		TxTos:                txTos,
+		TxDataHeaders:        txDataHeaders,
+		TxDatas:              txDatas,
+	}, nil
+}
+
+type BatchV2TxDataV3 interface {
+	txType() byte // returns the type ID
+}
+
+type BatchV2TxV3 struct {
+	inner BatchV2TxDataV3
+}
+
+type BatchV2LegacyTxDataV3 struct {
+	Value    *big.Int // wei amount
+	GasPrice *big.Int // wei per gas
+	Data     []byte
+}
+
+func (txData BatchV2LegacyTxDataV3) txType() byte { return types.LegacyTxType }
+
+type BatchV2AccessListTxDataV3 struct {
+	Value      *big.Int // wei amount
+	GasPrice   *big.Int // wei per gas
+	Data       []byte
+	AccessList types.AccessList // EIP-2930 access list
+}
+
+func (txData BatchV2AccessListTxDataV3) txType() byte { return types.AccessListTxType }
+
+type BatchV2DynamicFeeTxDataV3 struct {
+	Value      *big.Int
+	GasTipCap  *big.Int // a.k.a. maxPriorityFeePerGas
+	GasFeeCap  *big.Int // a.k.a. maxFeePerGas
+	Data       []byte
+	AccessList types.AccessList
+}
+
+func (txData BatchV2DynamicFeeTxDataV3) txType() byte { return types.DynamicFeeTxType }
+
+// Type returns the transaction type.
+func (tx *BatchV2TxV3) Type() uint8 {
+	return tx.inner.txType()
+}
+
+// encodeTyped writes the canonical encoding of a typed transaction to w.
+func (tx *BatchV2TxV3) encodeTyped(w *bytes.Buffer) error {
+	w.WriteByte(tx.Type())
+	return rlp.Encode(w, tx.inner)
+}
+
+// MarshalBinary returns the canonical encoding of the transaction.
+// For legacy transactions, it returns the RLP encoding. For EIP-2718 typed
+// transactions, it returns the type and payload.
+func (tx *BatchV2TxV3) MarshalBinary() ([]byte, error) {
+	if tx.Type() == types.LegacyTxType {
+		return rlp.EncodeToBytes(tx.inner)
+	}
+	var buf bytes.Buffer
+	err := tx.encodeTyped(&buf)
+	return buf.Bytes(), err
+}
+
+// EncodeRLP implements rlp.Encoder
+func (tx *BatchV2TxV3) EncodeRLP(w io.Writer) error {
+	if tx.Type() == types.LegacyTxType {
+		return rlp.Encode(w, tx.inner)
+	}
+	// It's an EIP-2718 typed TX envelope.
+	buf := encodeBufferPool.Get().(*bytes.Buffer)
+	defer encodeBufferPool.Put(buf)
+	buf.Reset()
+	if err := tx.encodeTyped(buf); err != nil {
+		return err
+	}
+	return rlp.Encode(w, buf.Bytes())
+}
+
+// setDecoded sets the inner transaction after decoding.
+func (tx *BatchV2TxV3) setDecoded(inner BatchV2TxData, size uint64) {
+	tx.inner = inner
+}
+
+// decodeTyped decodes a typed transaction from the canonical format.
+func (tx *BatchV2TxV3) decodeTyped(b []byte) (BatchV2TxData, error) {
+	if len(b) <= 1 {
+		return nil, errors.New("typed transaction too short")
+	}
+	switch b[0] {
+	case types.AccessListTxType:
+		var inner BatchV2AccessListTxData
+		err := rlp.DecodeBytes(b[1:], &inner)
+		return &inner, err
+	case types.DynamicFeeTxType:
+		var inner BatchV2DynamicFeeTxData
+		err := rlp.DecodeBytes(b[1:], &inner)
+		return &inner, err
+	default:
+		return nil, types.ErrTxTypeNotSupported
+	}
+}
+
+// DecodeRLP implements rlp.Decoder
+func (tx *BatchV2TxV3) DecodeRLP(s *rlp.Stream) error {
+	kind, size, err := s.Kind()
+	switch {
+	case err != nil:
+		return err
+	case kind == rlp.List:
+		// It's a legacy transaction.
+		var inner BatchV2LegacyTxData
+		err := s.Decode(&inner)
+		if err == nil {
+			tx.setDecoded(&inner, rlp.ListSize(size))
+		}
+		return err
+	default:
+		// It's an EIP-2718 typed TX envelope.
+		var b []byte
+		if b, err = s.Bytes(); err != nil {
+			return err
+		}
+		inner, err := tx.decodeTyped(b)
+		if err == nil {
+			tx.setDecoded(inner, uint64(len(b)))
+		}
+		return err
+	}
+}
+
+// UnmarshalBinary decodes the canonical encoding of transactions.
+// It supports legacy RLP transactions and EIP2718 typed transactions.
+func (tx *BatchV2TxV3) UnmarshalBinary(b []byte) error {
+	if len(b) > 0 && b[0] > 0x7f {
+		// It's a legacy transaction.
+		var data BatchV2LegacyTxData
+		err := rlp.DecodeBytes(b, &data)
+		if err != nil {
+			return err
+		}
+		tx.setDecoded(&data, uint64(len(b)))
+		return nil
+	}
+	// It's an EIP2718 typed transaction envelope.
+	inner, err := tx.decodeTyped(b)
+	if err != nil {
+		return err
+	}
+	tx.setDecoded(inner, uint64(len(b)))
+	return nil
+}
+
+// ConvertToFullTx takes values and convert BatchV2TxV3 to types.Transaction
+func (tx BatchV2TxV3) ConvertToFullTx(nonce, gas uint64, to *common.Address, chainID, V, R, S *big.Int) (*types.Transaction, error) {
+	var inner types.TxData
+	switch tx.Type() {
+	case types.LegacyTxType:
+		batchTxInner := tx.inner.(*BatchV2LegacyTxDataV3)
+		inner = &types.LegacyTx{
+			Nonce:    nonce,
+			GasPrice: batchTxInner.GasPrice,
+			Gas:      gas,
+			To:       to,
+			Value:    batchTxInner.Value,
+			Data:     batchTxInner.Data,
+			V:        V,
+			R:        R,
+			S:        S,
+		}
+	case types.AccessListTxType:
+		batchTxInner := tx.inner.(*BatchV2AccessListTxDataV3)
+		inner = &types.AccessListTx{
+			ChainID:    chainID,
+			Nonce:      nonce,
+			GasPrice:   batchTxInner.GasPrice,
+			Gas:        gas,
+			To:         to,
+			Value:      batchTxInner.Value,
+			Data:       batchTxInner.Data,
+			AccessList: batchTxInner.AccessList,
+			V:          V,
+			R:          R,
+			S:          S,
+		}
+	case types.DynamicFeeTxType:
+		batchTxInner := tx.inner.(*BatchV2DynamicFeeTxDataV3)
+		inner = &types.DynamicFeeTx{
+			ChainID:    chainID,
+			Nonce:      nonce,
+			GasTipCap:  batchTxInner.GasTipCap,
+			GasFeeCap:  batchTxInner.GasFeeCap,
+			Gas:        gas,
+			To:         to,
+			Value:      batchTxInner.Value,
+			Data:       batchTxInner.Data,
+			AccessList: batchTxInner.AccessList,
+			V:          V,
+			R:          R,
+			S:          S,
+		}
+	default:
+		return nil, fmt.Errorf("invalid tx type: %d", tx.Type())
+	}
+	return types.NewTx(inner), nil
+}
+
+func NewBatchV2TxV3(tx types.Transaction) (*BatchV2TxV3, error) {
+	var inner BatchV2TxDataV3
+	switch tx.Type() {
+	case types.LegacyTxType:
+		inner = BatchV2LegacyTxDataV3{
+			GasPrice: tx.GasPrice(),
+			Value:    tx.Value(),
+			Data:     tx.Data(),
+		}
+	case types.AccessListTxType:
+		inner = BatchV2AccessListTxDataV3{
+			GasPrice:   tx.GasPrice(),
+			Value:      tx.Value(),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+		}
+	case types.DynamicFeeTxType:
+		inner = BatchV2DynamicFeeTxDataV3{
+			GasTipCap:  tx.GasTipCap(),
+			GasFeeCap:  tx.GasFeeCap(),
+			Value:      tx.Value(),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+		}
+	default:
+		return nil, fmt.Errorf("invalid tx type: %d", tx.Type())
+	}
+	return &BatchV2TxV3{inner: inner}, nil
 }

--- a/op-node/rollup/derive/batch_tx_v3_test.go
+++ b/op-node/rollup/derive/batch_tx_v3_test.go
@@ -1,0 +1,53 @@
+package derive
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecoverV(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x12345678))
+
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+	totalblockTxCount := rng.Intn(100)
+
+	var batchTxsV3 BatchV2TxsV3
+	var txTypes []int
+	var txSigs []BatchV2Signature
+	var originalVs []uint64
+	yParityBits := new(big.Int)
+	for idx := 0; idx < totalblockTxCount; idx++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		txTypes = append(txTypes, int(tx.Type()))
+		var txSig BatchV2Signature
+		v, r, s := tx.RawSignatureValues()
+		// Do not fill in txSig.V
+		txSig.R, _ = uint256.FromBig(r)
+		txSig.S, _ = uint256.FromBig(s)
+		txSigs = append(txSigs, txSig)
+		originalVs = append(originalVs, v.Uint64())
+		yParityBit := ConvertVToYParity(v.Uint64(), int(tx.Type()))
+		yParityBits.SetBit(yParityBits, idx, yParityBit)
+	}
+
+	batchTxsV3.ChainID = chainID
+	batchTxsV3.YParityBits = yParityBits
+	batchTxsV3.TxSigs = txSigs
+
+	// recover txSig.V
+	batchTxsV3.RecoverV(txTypes)
+
+	var recoveredVs []uint64
+	for _, txSig := range batchTxsV3.TxSigs {
+		recoveredVs = append(recoveredVs, txSig.V)
+	}
+
+	assert.Equal(t, originalVs, recoveredVs, "recovered v mismatch")
+}

--- a/specs/span-batch-format-proposal.md
+++ b/specs/span-batch-format-proposal.md
@@ -82,4 +82,4 @@ Our goal is to find the sweet spot on code complexity - span batch size tradeoff
 
 For legacy type transactions, `v = 2 * ChainID + y_parity`. For other types of transactions, `v = y_parity`. We may only store `y_parity`, which is single bit per L2 transction.
 
-This optimization will benefit more when ratio between number of legacy type transactions over number of transactions excluding deposit tx is higher.
+This optimization will benefit more when ratio between number of legacy type transactions over number of transactions excluding deposit tx is higher. Deposit transactions are excluded in batches and are never written at L1 so excluded while analyzing.

--- a/specs/span-batch-format-proposal.md
+++ b/specs/span-batch-format-proposal.md
@@ -29,7 +29,7 @@ Where:
   - `l1_origin_check`: to ensure the intended L1 origins of this span of
         L2 blocks are consistent with the L1 chain, the blockhash of the last L1 origin is referenced.
         The hash is truncated to 20 bytes for efficiency, i.e. `span_end.l1_origin.hash[:20]`.
-- `payload = block_count ++ block_tx_counts ++ txs`:
+- `payload = block_count ++ origin_bits ++ block_tx_counts ++ txs`:
   - `block_count`: `uvarint` number of L2 blocks.
   - `origin_bits`: bitlist of `block_count` bits, right-padded to a multiple of 8 bits:
     1 bit per L2 block, indicating if the L1 origin changed this L2 block.

--- a/specs/span-batch-format-proposal.md
+++ b/specs/span-batch-format-proposal.md
@@ -1,0 +1,79 @@
+## Span batch format
+
+Note that span-batches, unlike previous V0 batches,
+encode *a range of consecutive* L2 blocks at the same time.
+
+Introduce version `1` to the [batch-format](./derivation.md#batch-format) table:
+
+| `batch_version` | `content`           |
+|-----------------|---------------------|
+| 1               | `prefix ++ payload` |
+
+Notation:
+- `++`: concatenation of byte-strings
+- `span_start`: first L2 block in the span
+- `span_end`: last L2 block in the span
+- `uvarint`: unsigned Base128 varint, as defined in [protobuf spec]
+- `rlp_encode`: a function that encodes a batch according to the [RLP format], and `[x, y, z]` denotes a list containing items `x`, `y` and `z`
+
+[protobuf spec]: https://protobuf.dev/programming-guides/encoding/#varints
+
+[RLP format]: https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
+
+Where:
+
+- `prefix = rel_timestamp ++ l1_origin_num ++ parent_check ++ l1_origin_check`
+  - `rel_timestamp`: relative time since genesis, i.e. `span_start.timestamp - config.genesis.timestamp`.
+  - `l1_origin_num`: `uvarint` number of l1 origin number.
+  - `parent_check`: first 20 bytes of parent hash, i.e. `span_start.parent_hash[:20]`.
+  - `l1_origin_check`: to ensure the intended L1 origins of this span of
+        L2 blocks are consistent with the L1 chain, the blockhash of the last L1 origin is referenced.
+        The hash is truncated to 20 bytes for efficiency, i.e. `span_end.l1_origin.hash[:20]`.
+- `payload = block_count ++ block_tx_counts ++ txs`:
+  - `block_count`: `uvarint` number of L2 blocks.
+  - `origin_bits`: bitlist of `block_count` bits, right-padded to a multiple of 8 bits:
+    1 bit per L2 block, indicating if the L1 origin changed this L2 block.
+  - `block_tx_counts`: for each block, a `uvarint` of `len(block.transactions)`.
+  - `txs`: L2 transactions which is reorganized and encoded as below.
+- `txs = contract_creation_bits ++ tx_sigs ++ tx_nonces ++ tx_gases ++ tx_tos ++ tx_datas`
+  - `contract_creation_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits, 1 bit per L2 transactions, indicating if transaction is a contract creation transaction.
+  - `tx_sigs`: concatenated list of transaction signatures
+    - `v`, or `y_parity`, is encoded as `uvarint` (some legacy transactions combine the chain ID)
+    - `r` is encoded as big-endian `uint256`
+    - `s` is encoded as big-endian `uint256`
+  - `tx_nonces`: concatenated list of `uvarint` of `nonce` field.
+  - `tx_gases`:  concatenated list of `uvarint` of gas limits.
+    - `legacy`: `gasLimit`
+    - `1`: ([EIP-2930]): `gasLimit`
+    - `2`: ([EIP-1559]): `gas_limit`
+  - `tx_tos`: concatenated list of `to` field. `to` field in contract creation transaction will be `nil` and ignored.
+  - `tx_datas`: concatenated list of variable length rlp encoded data
+    - `legacy`: `rlp_encode(value, gasPrice, data)`
+    - `1`: ([EIP-2930]): `rlp_encode(value, gasPrice, data, accessList)`
+    - `2`: ([EIP-1559]): `rlp_encode(value, max_priority_fee_per_gas, max_fee_per_gas, data, access_list)`
+
+[EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+
+[EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
+
+### Optimization Strategy
+
+#### `tx_data_headers` Removal
+
+We do not need to store length per each `tx_datas` elements even if those are variable length, because the elements itself is RLP encoded, containing their length in RLP prefix.
+
+#### `Chain ID` Removal
+
+Every transaction has chain id. We do not need to include chain id in span batch because L2 already knows its chain id, and use its own value for processing span batches while derivation.
+
+#### Reorganization of constant length transaction fields
+
+`signature`, `nonce`, `gaslimit`, `to` field are constant size, so these were split up completely and are grouped into individual arrays. This adds more complexity, but organizes data for improved compression.
+
+#### RLP encoding for variable length fields
+
+Further size optimization can be done by customly packing variable length fields, such as `access_list`. However doing this will introduce much more code complexity, comparing to benefitting by size reduction.
+
+Our goal is to find the sweet spot on code complexity - span batch size tradeoff. I decided that using RLP for all variable length fields will be the best option, not risking codebase with gnarly custom encoding/decoding implementations.

--- a/specs/span-batch-format-proposal.md
+++ b/specs/span-batch-format-proposal.md
@@ -47,10 +47,10 @@ Where:
     - `1`: ([EIP-2930]): `gasLimit`
     - `2`: ([EIP-1559]): `gas_limit`
   - `tx_tos`: concatenated list of `to` field. `to` field in contract creation transaction will be `nil` and ignored.
-  - `tx_datas`: concatenated list of variable length rlp encoded data
+  - `tx_datas`: concatenated list of variable length rlp encoded data follwing [EIP-2718] encoded format using `TransactionType`.
     - `legacy`: `rlp_encode(value, gasPrice, data)`
-    - `1`: ([EIP-2930]): `rlp_encode(value, gasPrice, data, accessList)`
-    - `2`: ([EIP-1559]): `rlp_encode(value, max_priority_fee_per_gas, max_fee_per_gas, data, access_list)`
+    - `1`: ([EIP-2930]): `0x01 ++ rlp_encode(value, gasPrice, data, accessList)`
+    - `2`: ([EIP-1559]): `0x02 ++ rlp_encode(value, max_priority_fee_per_gas, max_fee_per_gas, data, access_list)`
 
 [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 


### PR DESCRIPTION
This PR abstracts out tx data from Span Batch, using interface.

Required for experimenting multiple tx encoding schemes.
struct `BatchV2TxsV1` implements interface `BatchV2Txs`, following the spec docs.
will try other implementations:
- `BatchV2TxsV2`: RLP encode full tx without field separation. This may reduce effect of span batch.
- `BatchV2TxsV3`: According to the spec docs, `tx_data entries may be split up completely and tx attributes could be grouped into individual arrays, similar to signatures.`. Try this. This may make effect of span batch better.
