### PR TITLE
Span Batch: Store y parity instead of V 

### DIFF
--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -21,6 +21,7 @@ type BatchV2TxsV3 struct {
 	ChainID           *big.Int
 
 	ContractCreationBits *big.Int
+	YParityBits          *big.Int
 	TxSigs               []BatchV2Signature
 	TxNonces             []uint64
 	TxGases              []uint64
@@ -78,17 +79,75 @@ func (btx *BatchV2TxsV3) ContractCreationCount() (uint64, error) {
 	return result, nil
 }
 
+func (btx *BatchV2TxsV3) EncodeYParityBits() []byte {
+	yParityBitBufferLen := btx.TotalBlockTxCount / 8
+	if btx.TotalBlockTxCount%8 != 0 {
+		yParityBitBufferLen++
+	}
+	yParityBitBuffer := make([]byte, yParityBitBufferLen)
+	for i := 0; i < int(btx.TotalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.TotalBlockTxCount) {
+			end = int(btx.TotalBlockTxCount)
+		}
+		var bits uint = 0
+		for j := i; j < end; j++ {
+			bits |= btx.YParityBits.Bit(j) << (j - i)
+		}
+		yParityBitBuffer[i/8] = byte(bits)
+	}
+	return yParityBitBuffer
+}
+
+func (btx *BatchV2TxsV3) DecodeYParityBits(yParityBitBuffer []byte) {
+	yParityBits := new(big.Int)
+	for i := 0; i < int(btx.TotalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.TotalBlockTxCount) {
+			end = int(btx.TotalBlockTxCount)
+		}
+		bits := yParityBitBuffer[i/8]
+		for j := i; j < end; j++ {
+			bit := uint((bits >> (j - i)) & 1)
+			yParityBits.SetBit(yParityBits, j, bit)
+		}
+	}
+	btx.YParityBits = yParityBits
+}
+
+func (btx *BatchV2TxsV3) RecoverV(txTypes []int) {
+	if len(txTypes) != len(btx.TxSigs) {
+		panic("tx type length and tx sigs length mismatch")
+	}
+	for idx, txType := range txTypes {
+		bit := uint64(btx.YParityBits.Bit(idx))
+		var v uint64
+		switch txType {
+		case types.LegacyTxType:
+			// EIP155
+			v = btx.ChainID.Uint64()*2 + 35 + bit
+		case types.AccessListTxType:
+			v = bit
+		case types.DynamicFeeTxType:
+			v = bit
+		default:
+			panic(fmt.Sprintf("invalid tx type: %d", txType))
+		}
+		btx.TxSigs[idx].V = v
+	}
+}
+
 func (btx *BatchV2TxsV3) Encode(w io.Writer) error {
 	var buf [binary.MaxVarintLen64]byte
 	contractCreationBitBuffer := btx.EncodeContractCreationBits()
 	if _, err := w.Write(contractCreationBitBuffer); err != nil {
 		return fmt.Errorf("cannot write contract creation bits: %w", err)
 	}
+	yParityBitBuffer := btx.EncodeYParityBits()
+	if _, err := w.Write(yParityBitBuffer); err != nil {
+		return fmt.Errorf("cannot write y parity bits: %w", err)
+	}
 	for _, txSig := range btx.TxSigs {
-		n := binary.PutUvarint(buf[:], txSig.V)
-		if _, err := w.Write(buf[:n]); err != nil {
-			return fmt.Errorf("cannot write tx sig v: %w", err)
-		}
 		rBuf := txSig.R.Bytes32()
 		if _, err := w.Write(rBuf[:]); err != nil {
 			return fmt.Errorf("cannot write tx sig r: %w", err)
@@ -133,15 +192,19 @@ func (btx *BatchV2TxsV3) Decode(r *bytes.Reader) error {
 	if err != nil {
 		return fmt.Errorf("failed to read contract creation bits: %w", err)
 	}
+	yParityBitBufferLen := btx.TotalBlockTxCount / 8
+	if btx.TotalBlockTxCount%8 != 0 {
+		yParityBitBufferLen++
+	}
+	yParityBitBuffer := make([]byte, yParityBitBufferLen)
+	_, err = io.ReadFull(r, yParityBitBuffer)
+	if err != nil {
+		return fmt.Errorf("failed to read y parity bits: %w", err)
+	}
 	txSigs := make([]BatchV2Signature, btx.TotalBlockTxCount)
 	var sigBuffer [32]byte
 	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
 		var txSig BatchV2Signature
-		v, err := binary.ReadUvarint(r)
-		if err != nil {
-			return fmt.Errorf("failed to read tx sig v: %w", err)
-		}
-		txSig.V = v
 		_, err = io.ReadFull(r, sigBuffer[:])
 		if err != nil {
 			return fmt.Errorf("failed to read tx sig r: %w", err)
@@ -185,15 +248,19 @@ func (btx *BatchV2TxsV3) Decode(r *bytes.Reader) error {
 		txTos = append(txTos, common.BytesToAddress(txToBuffer))
 	}
 	txDatas := make([]hexutil.Bytes, btx.TotalBlockTxCount)
+	txTypes := make([]int, btx.TotalBlockTxCount)
 	// Do not need txDataHeader because RLP byte stream already includes length info
 	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
-		txData, err := ReadTxData(r)
+		txData, txType, err := ReadTxData(r)
 		if err != nil {
 			return err
 		}
 		txDatas[i] = txData
+		txTypes[i] = txType
 	}
 	btx.TxSigs = txSigs
+	btx.DecodeYParityBits(yParityBitBuffer)
+	btx.RecoverV(txTypes)
 	btx.TxNonces = txNonces
 	btx.TxGases = txGases
 	btx.TxTos = txTos
@@ -244,6 +311,7 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 	var txGases []uint64
 	var txDatas []hexutil.Bytes
 	contractCreationBits := new(big.Int)
+	yParityBits := new(big.Int)
 	for idx := 0; idx < int(totalBlockTxCount); idx++ {
 		var tx types.Transaction
 		if err := tx.UnmarshalBinary(txs[idx]); err != nil {
@@ -263,6 +331,20 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 			contractCreationBit = uint(0)
 		}
 		contractCreationBits.SetBit(contractCreationBits, idx, contractCreationBit)
+		var yParityBit uint
+		switch tx.Type() {
+		case types.LegacyTxType:
+			// EIP155: v = 2 * chainID + 35 + yParity
+			// v - 35 = yParity (mod 2)
+			yParityBit = uint((txSig.V - 35) & 1)
+		case types.AccessListTxType:
+			yParityBit = uint(txSig.V)
+		case types.DynamicFeeTxType:
+			yParityBit = uint(txSig.V)
+		default:
+			panic(fmt.Sprintf("invalid tx type: %d", tx.Type()))
+		}
+		yParityBits.SetBit(yParityBits, idx, yParityBit)
 		txNonces = append(txNonces, tx.Nonce())
 		txGases = append(txGases, tx.Gas())
 		batchV2TxV3, err := NewBatchV2TxV3(tx)
@@ -279,6 +361,7 @@ func NewBatchV2TxsV3(txs [][]byte) (*BatchV2TxsV3, error) {
 		TotalBlockTxCount:    totalBlockTxCount,
 		ChainID:              ChainID, // TODO: fix hardcoded chainID
 		ContractCreationBits: contractCreationBits,
+		YParityBits:          yParityBits,
 		TxSigs:               txSigs,
 		TxNonces:             txNonces,
 		TxGases:              txGases,

--- a/op-node/rollup/derive/batch_tx_v3_test.go
+++ b/op-node/rollup/derive/batch_tx_v3_test.go
@@ -1,0 +1,53 @@
+package derive
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecoverV(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x12345678))
+
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+	totalblockTxCount := rng.Intn(100)
+
+	var batchTxsV3 BatchV2TxsV3
+	var txTypes []int
+	var txSigs []BatchV2Signature
+	var originalVs []uint64
+	yParityBits := new(big.Int)
+	for idx := 0; idx < totalblockTxCount; idx++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		txTypes = append(txTypes, int(tx.Type()))
+		var txSig BatchV2Signature
+		v, r, s := tx.RawSignatureValues()
+		// Do not fill in txSig.V
+		txSig.R, _ = uint256.FromBig(r)
+		txSig.S, _ = uint256.FromBig(s)
+		txSigs = append(txSigs, txSig)
+		originalVs = append(originalVs, v.Uint64())
+		yParityBit := ConvertVToYParity(v.Uint64(), int(tx.Type()))
+		yParityBits.SetBit(yParityBits, idx, yParityBit)
+	}
+
+	batchTxsV3.ChainID = chainID
+	batchTxsV3.YParityBits = yParityBits
+	batchTxsV3.TxSigs = txSigs
+
+	// recover txSig.V
+	batchTxsV3.RecoverV(txTypes)
+
+	var recoveredVs []uint64
+	for _, txSig := range batchTxsV3.TxSigs {
+		recoveredVs = append(recoveredVs, txSig.V)
+	}
+
+	assert.Equal(t, originalVs, recoveredVs, "recovered v mismatch")
+}

--- a/specs/span-batch-format-proposal.md
+++ b/specs/span-batch-format-proposal.md
@@ -82,4 +82,4 @@ Our goal is to find the sweet spot on code complexity - span batch size tradeoff
 
 For legacy type transactions, `v = 2 * ChainID + y_parity`. For other types of transactions, `v = y_parity`. We may only store `y_parity`, which is single bit per L2 transction.
 
-This optimization will benefit more when ratio between number of legacy type transactions over number of transactions excluding deposit tx is higher.
+This optimization will benefit more when ratio between number of legacy type transactions over number of transactions excluding deposit tx is higher. Deposit transactions are excluded in batches and are never written at L1 so excluded while analyzing.


### PR DESCRIPTION
We can reduce `v` to a single bit. This reduces at least 7 bits per transaction.
- Rationale: We can derive `v`!
- `v` is needed for the transaction sender from the signature to choose secp256k1 curve points between two candidates (technically four, but omitted due to unlikely probability)
- For legacy transactions(EIP-155), `v = 2 * chainID + 35 + y_parity` . Only save `y_parity` instead of the entire `v`.

Tx type stats:
- Mainnet: 105235063(bedrock genesis) to 108421982:`LegacyTx percentage excluding DepositTx: 46.977879897191976`: `19665928 / 41862102`
- Goerli:  4061224(bedrock genesis) to 13507550: `LegacyTx percentage excluding DepositTx: 19.916573644000916`: `3647449 / 18313637`

Significant amount of user transactions are legacy transactions, at least 19%. Therefore this optimization is worth to be done.

When this PR is merged, pcw109550/span-batch-tester-with-tx-encoding will be backmerged: [pcw109550/span-batch-tx-encoding](https://github.com/testinprod-io/optimism/tree/pcw109550/span-batch-tx-encoding) ->  pcw109550/span-batch-tester-with-tx-encoding.