### PR TITLE
Add BatchV2 version with fee recipent field

### DIFF
--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -343,7 +343,6 @@ func (b BatchV2) PrefixSize() (int, error) {
 
 func (b BatchV2) MetadataSize() (int, error) {
 	// define metadata as every data except tx related field
-	// start with 1 because of version field
 	size := 0
 	prefixSize, err := b.PrefixSize()
 	if err != nil {

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -234,7 +234,7 @@ func (b *BatchV2Payload) DecodeOriginBits(originBitBuffer []byte, blockCount uin
 }
 
 func (b *BatchV2) DecodeFeeRecipents(r *bytes.Reader) error {
-	if b.BatchV2Version > BatchV2V1 {
+	if b.BatchV2Version < BatchV2V2 {
 		return nil
 	}
 	var idxs []uint64
@@ -410,7 +410,7 @@ func (b *BatchV2) EncodeVersion(w io.Writer) error {
 
 // EncodeFeeRecipents parses data into b.FeeRecipents
 func (b *BatchV2) EncodeFeeRecipents(w io.Writer) error {
-	if b.BatchV2Version > BatchV2V1 {
+	if b.BatchV2Version < BatchV2V2 {
 		return nil
 	}
 	var buf [binary.MaxVarintLen64]byte

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -28,7 +28,9 @@ import (
 // An empty input is not a valid batch.
 //
 // Note: the type system is based on L1 typed transactions.
-// BatchV2V1Type := 1
+// BatchV2Type
+//   BatchV2V1Type := 1
+//   BatchV2V2Type := 2 (with fee recipent)
 // batchV2 := BatchV2Type ++ prefix ++ payload
 // prefix := rel_timestamp ++ l1_origin_num ++ parent_check ++ l1_origin_check
 // payload := block_count ++ origin_bits ++ block_tx_counts ++ txs

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -64,9 +64,9 @@ func RandomBatchV2V1(rng *rand.Rand) *BatchData {
 		panic("NewBatchV2TxsV?:" + err.Error())
 	}
 	return &BatchData{
-		BatchType: BatchV2Type,
+		BatchType: BatchV2V1Type,
 		BatchV2: BatchV2{
-			BatchV2Version: BatchV2V1,
+			BatchV2Version: BatchV2V1Type,
 			BatchV2Prefix: BatchV2Prefix{
 				RelTimestamp:  rng.Uint64(),
 				L1OriginNum:   rng.Uint64(),
@@ -85,7 +85,8 @@ func RandomBatchV2V1(rng *rand.Rand) *BatchData {
 
 func RandomBatchV2V2(rng *rand.Rand) *BatchData {
 	batchData := RandomBatchV2V1(rng)
-	batchData.BatchV2.BatchV2Version = BatchV2V2
+	batchData.BatchType = BatchV2V2Type
+	batchData.BatchV2.BatchV2Version = BatchV2V2Type
 	// FeeRecipent length
 	N := int(batchData.BatchV2.BlockCount)
 	// cardinality of FeeRecipent

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -142,6 +142,9 @@ func TestBatchRoundTrip(t *testing.T) {
 		RandomBatchV1(rng, 5),
 		RandomBatchV1(rng, 7),
 		RandomBatchV2V1(rng),
+		RandomBatchV2V1(rng),
+		RandomBatchV2V2(rng),
+		RandomBatchV2V2(rng),
 	}
 
 	for i, batch := range batches {


### PR DESCRIPTION
Added `BatchV2Version` to span batch struct, although this field is equal to batch version. 

If `BatchV2Version = BatchV2V1`, does not try to handle fee recipent field.
If `BatchV2Version = BatchV2V2`, span batch tries to parse fee recipent field.

Rationale: we can manage a index for storing fee recipents instead of naively storing as an array.

For example, if fee receipt list is like [address A, address B, address C, address B, address C], we can make a map. 0: address A, 1: address B, 2: address C. We encode indexes as uvarint, and store the cardinal addresses as array after that. So data layout will be in this case: `uvarint(0) || uvarint(1) || uvarint(2) || uvarint(1) || uvarint(2) || address A || address B || address C`.

Comparing to naively gzipping array of address, the index method showed better compression when the cardinality(`len(set(list of fee recipent)))`) is less than total address count(`len(list of fee recipent)`).

For example, Let cardinality `K = 3` and total recipent length `N = 200`. Compression comparison code:
```go
package main

import (
	"bytes"
	"compress/gzip"
	"encoding/binary"
	"encoding/hex"
	"fmt"
	"math/rand"
	"time"

	"github.com/ethereum-optimism/optimism/op-node/testutils"
	"github.com/ethereum/go-ethereum/common"
)

func compressData(data []byte) ([]byte, error) {
	var buf bytes.Buffer
	gz, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
	if err != nil {
		return nil, err
	}
	_, err = gz.Write(data)
	if err != nil {
		return nil, err
	}
	if err := gz.Close(); err != nil {
		return nil, err
	}
	return buf.Bytes(), nil
}

func main() {
	N := 300  // Mainnet: 300 * 2s = 600s = 10 min Goerli: 30 * 2s = 60s = 1min
	K := 3
	rng := rand.New(rand.NewSource(time.Now().UnixNano()))

	var addressSet []common.Address
	for i := 0; i < K; i++ {
 		address := testutils.RandomAddress(rng)
		addressSet = append(addressSet, address)
		fmt.Println(i, hex.EncodeToString(address.Bytes()))
	}

	var addressList []common.Address
	var addressIdxs []uint64
	for i := 0; i < N; i++ {
		addressIdx := uint64(rand.Intn(len(addressSet)))
		addressList = append(addressList, addressSet[addressIdx])
		addressIdxs = append(addressIdxs, addressIdx)
	}

	var dataV1 []byte
	for _, address := range addressList {
		dataV1 = append(dataV1, address.Bytes()...)
	}

	var dataV2 []byte
	for _, address := range addressSet {
		dataV2 = append(dataV2, address.Bytes()...)
	}
	fmt.Println("dataV2 length only address:", len(dataV2))

	var uvarBuf [binary.MaxVarintLen64]byte
	buf := new(bytes.Buffer)
	for _, addressIdx := range addressIdxs {
		n := binary.PutUvarint(uvarBuf[:], addressIdx)
		if _, err := buf.Write(uvarBuf[:n]); err != nil {
			panic("at the disco")
		}
	}
	dataV2 = append(dataV2, buf.Bytes()...)

	fmt.Println("dataV1 length:", len(dataV1))
	fmt.Println("dataV2 length:", len(dataV2))

	buf.Reset()

	dataV1Compressed, err := compressData(dataV1)
	if err != nil {
		panic(err)
	}
	dataV2Compressed, err := compressData(dataV2)
	if err != nil {
		panic(err)
	}

	fmt.Println("dataV1Compressed length:", len(dataV1Compressed))
	fmt.Println("dataV2Compressed length:", len(dataV2Compressed))

	fmt.Println(12 * N, 20 * K)
}
```

Result:
```
0 409fe8949241217d8e8db271b9ec00a4f71b52aa
1 eacd4bf1a04dfae68d9788269bcc2e8850fb75ee
2 04b36a3de0b1d9fbb711144dbc15fd408234b185
dataV2 length only address: 60
dataV1 length: 6000
dataV2 length: 360
dataV1Compressed length: 303
dataV2Compressed length: 234
3600 60
```

Lesser cardinality, better compression. However if cardinality reaches certain point, this index method will be worse than naive list encoding, because it uses additional memory for storing indexes.





