### PR TITLE
Span Batch Data Layout

### DIFF
--- a/op-node/cmd/span_batch_tester/format/format.go
+++ b/op-node/cmd/span_batch_tester/format/format.go
@@ -1,0 +1,95 @@
+package format
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"path"
+
+	"github.com/ethereum-optimism/optimism/op-node/cmd/span_batch_tester/analyze"
+	"github.com/ethereum-optimism/optimism/op-node/cmd/span_batch_tester/convert"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+)
+
+type Config struct {
+	InSpanBatchDirectory string
+	OutDirectory         string
+	ChainID              *big.Int
+}
+
+func calcCompressedSize(data []byte) int {
+	var buf bytes.Buffer
+	w, err := zlib.NewWriterLevel(&buf, zlib.BestCompression)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = w.Write(data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		log.Fatal(err)
+	}
+	return buf.Len()
+}
+
+func Compare(batchV2 convert.SpanBatchWithMetadata) (int, int) {
+	derive.BatchV2TxsV3FieldPerm = []int{0, 1, 2, 3, 4, 5, 6}
+	spanBatchEncoded, err := batchV2.BatchV2.EncodeBytes()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	spanBatchCompressedSizeA := calcCompressedSize(spanBatchEncoded)
+
+	//	derive.BatchV2TxsV3FieldPerm = []int{3, 0, 4, 1, 2, 6, 5}
+
+	derive.BatchV2TxsV3FieldPerm = []int{0, 1, 2, 3, 4, 6, 5}
+
+	spanBatchEncoded, err = batchV2.BatchV2.EncodeBytes()
+	if err != nil {
+		log.Fatal(err)
+	}
+	spanBatchCompressedSizeB := calcCompressedSize(spanBatchEncoded)
+
+	// if delta is positive, our new permutation gives smaller size
+	delta := spanBatchCompressedSizeA - spanBatchCompressedSizeB
+
+	return delta , spanBatchCompressedSizeA
+}
+
+func Format(config Config) {
+	// update global varibles. Weird but works
+	derive.ChainID = config.ChainID
+	if err := os.MkdirAll(config.OutDirectory, 0750); err != nil {
+		log.Fatal(err)
+	}
+	spanBatchFiles, err := os.ReadDir(config.InSpanBatchDirectory)
+	if err != nil {
+		log.Fatal(err)
+	}
+	derive.InitializePermutations()
+
+	cnt := 0
+	deltaSum := 0
+	originalCompressedSizeSum := 0
+	for i, spanBatchFile := range spanBatchFiles {
+		batchV2Filename := path.Join(config.InSpanBatchDirectory, spanBatchFile.Name())
+		fmt.Println(i, batchV2Filename)
+
+		// always reset perm to pass span batch hash check
+		derive.BatchV2TxsV3FieldPerm = []int{0, 1, 2, 3, 4, 5, 6}
+		batchV2 := analyze.LoadSpanBatch(batchV2Filename)
+		delta, originalCompressedSize := Compare(batchV2)
+		if delta >= 0 {
+			cnt++
+		}
+		deltaSum += delta
+		originalCompressedSizeSum += originalCompressedSize
+		fmt.Printf("[%d/%d] %d %d %d\n", cnt, len(spanBatchFiles), delta, deltaSum, originalCompressedSizeSum)
+		fmt.Println(100 * float64(deltaSum) / float64(originalCompressedSizeSum))
+	}
+}

--- a/op-node/cmd/span_batch_tester/format/format.go
+++ b/op-node/cmd/span_batch_tester/format/format.go
@@ -64,9 +64,12 @@ func Compare(batchV2 convert.SpanBatchWithMetadata) (int, int) {
 func Format(config Config) {
 	// update global varibles. Weird but works
 	derive.ChainID = config.ChainID
+
+	// out directory currently not used
 	if err := os.MkdirAll(config.OutDirectory, 0750); err != nil {
 		log.Fatal(err)
 	}
+
 	spanBatchFiles, err := os.ReadDir(config.InSpanBatchDirectory)
 	if err != nil {
 		log.Fatal(err)

--- a/op-node/cmd/span_batch_tester/format/format.go
+++ b/op-node/cmd/span_batch_tester/format/format.go
@@ -47,6 +47,7 @@ func Compare(batchV2 convert.SpanBatchWithMetadata) (int, int) {
 
 	//	derive.BatchV2TxsV3FieldPerm = []int{3, 0, 4, 1, 2, 6, 5}
 
+	// choose your permutation
 	derive.BatchV2TxsV3FieldPerm = []int{0, 1, 2, 3, 4, 6, 5}
 
 	spanBatchEncoded, err = batchV2.BatchV2.EncodeBytes()

--- a/op-node/cmd/span_batch_tester/main.go
+++ b/op-node/cmd/span_batch_tester/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/cmd/span_batch_tester/analyze"
 	"github.com/ethereum-optimism/optimism/op-node/cmd/span_batch_tester/convert"
 	"github.com/ethereum-optimism/optimism/op-node/cmd/span_batch_tester/fetch"
+	"github.com/ethereum-optimism/optimism/op-node/cmd/span_batch_tester/format"
 	"github.com/ethereum-optimism/optimism/op-node/cmd/span_batch_tester/merge"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -246,6 +247,40 @@ func main() {
 					return err
 				}
 				fmt.Printf("Merged v0 batches in range [%v,%v).\n", config.Start, config.End)
+				return nil
+			},
+		},
+		{
+			Name:  "format",
+			Usage: "Search for best span batch format",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "in-span-batch",
+					Value: "/tmp/span_batch_tester/span_batch_cache",
+					Usage: "Cache directory for the converted batch",
+				},
+				&cli.StringFlag{
+					Name:  "out",
+					Value: "/tmp/span_batch_tester/format_result",
+					Usage: "Directory for the format result",
+				},
+				&cli.IntFlag{
+					Name:     "chain-id",
+					Required: true,
+					Usage:    "L2 chain id",
+					Value:    10,
+				},
+			},
+			Action: func(cliCtx *cli.Context) error {
+				// transaction encoding type is always BatchV2TxsV3Type
+				derive.BatchV2TxsType = derive.BatchV2TxsV3Type
+				chainID := big.NewInt(cliCtx.Int64("chain-id"))
+				config := format.Config{
+					InSpanBatchDirectory: cliCtx.String("in-span-batch"),
+					OutDirectory:         cliCtx.String("out"),
+					ChainID:              chainID,
+				}
+				format.Format(config)
 				return nil
 			},
 		},

--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -312,6 +312,7 @@ func (btx *BatchV2TxsV3) Encode(w io.Writer) error {
 	if err := btx.EncodeTxGases(w); err != nil {
 		return err
 	}
+	// Must be called after EncodeContractCreationBits
 	if err := btx.EncodeTxTos(w); err != nil {
 		return err
 	}

--- a/op-node/rollup/derive/batch_tx_v3.go
+++ b/op-node/rollup/derive/batch_tx_v3.go
@@ -15,6 +15,9 @@ import (
 	"github.com/holiman/uint256"
 )
 
+// adjust this for permuting data layout
+var BatchV2TxsV3Perm = []int{0, 1, 2, 3, 4, 5, 6}
+
 type BatchV2TxsV3 struct {
 	// these two fields must be manually set
 	TotalBlockTxCount uint64
@@ -342,7 +345,12 @@ func (btx *BatchV2TxsV3) Encode(w io.Writer) error {
 			return nil
 		},
 	}
-	for _, encodeFunc := range encodeFuncs {
+
+	if len(BatchV2TxsV3Perm) != len(encodeFuncs) {
+		panic("invalid permutation")
+	}
+	for _, idx := range BatchV2TxsV3Perm {
+		encodeFunc := encodeFuncs[idx]
 		if err := encodeFunc(); err != nil {
 			return err
 		}
@@ -399,7 +407,12 @@ func (btx *BatchV2TxsV3) Decode(r *bytes.Reader) error {
 			return nil
 		},
 	}
-	for _, decodeFunc := range decodeFuncs {
+
+	if len(BatchV2TxsV3Perm) != len(decodeFuncs) {
+		panic("invalid permutation")
+	}
+	for _, idx := range BatchV2TxsV3Perm {
+		decodeFunc := decodeFuncs[idx]
 		if err := decodeFunc(); err != nil {
 			return err
 		}

--- a/op-node/rollup/derive/batch_tx_v3_test.go
+++ b/op-node/rollup/derive/batch_tx_v3_test.go
@@ -51,3 +51,29 @@ func TestRecoverV(t *testing.T) {
 
 	assert.Equal(t, originalVs, recoveredVs, "recovered v mismatch")
 }
+
+func TestTxFieldPermutation(t *testing.T) {
+	InitializePermutations()
+
+	rng := rand.New(rand.NewSource(0x4141414141414141))
+
+	K := 100
+	rand.Shuffle(len(BatchV2TxsV3FieldPerms), func(i, j int) {
+		BatchV2TxsV3FieldPerms[i], BatchV2TxsV3FieldPerms[j] = BatchV2TxsV3FieldPerms[j], BatchV2TxsV3FieldPerms[i]
+	})
+
+	// try marshaling with each permutations
+	// we do not permute every possiblity because it takes over 30s to do so
+	for _, perm := range BatchV2TxsV3FieldPerms[:K] {
+		// update global variable
+		BatchV2TxsV3FieldPerm = perm
+
+		batch := RandomBatchV2V1(rng)
+		enc, err := batch.MarshalBinary()
+		assert.NoError(t, err)
+		var dec BatchData
+		err = dec.UnmarshalBinary(enc)
+		assert.NoError(t, err)
+		assert.Equal(t, batch, &dec, "Batch not equal test case %v", perm)
+	}
+}

--- a/op-node/rollup/derive/batch_tx_v3_test.go
+++ b/op-node/rollup/derive/batch_tx_v3_test.go
@@ -77,3 +77,24 @@ func TestTxFieldPermutation(t *testing.T) {
 		assert.Equal(t, batch, &dec, "Batch not equal test case %v", perm)
 	}
 }
+
+func TestTxFieldInvalidPermutation(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		} else if r != "contract creation bits not set" {
+			t.Errorf("Unexpected panic message: %v", r)
+		}
+	}()
+
+	rng := rand.New(rand.NewSource(0x4242424242424242))
+
+	// TxTos helper function first called before ContractCreationBits helper
+	BatchV2TxsV3FieldPerm = []int{5, 1, 2, 3, 4, 0, 6}
+	batch := RandomBatchV2V1(rng)
+	enc, err := batch.MarshalBinary()
+	assert.NoError(t, err)
+	var dec BatchData
+
+	dec.UnmarshalBinary(enc)
+}


### PR DESCRIPTION
## Example Usage

command example:
```sh
./cmd/span_batch_tester/span_batch_tester format --in-span-batch=./artifacts/mainnet/span_batch_cache_v3 --out=./artifacts/mainnet/format_result_v3 --chain-id=10

./cmd/span_batch_tester/span_batch_tester format --in-span-batch=./artifacts/goerli/span_batch_cache_v3 --out=./artifacts/goerli/format_result_v3 --chain-id=420
```

## Analysis

Tx data layout has below 7 fields:
```
	ContractCreationBits *big.Int
	YParityBits          *big.Int
	TxSigs               []BatchV2Signature
	TxNonces             []uint64
	TxGases              []uint64
	TxTos                []common.Address
	TxDatas              []hexutil.Bytes
```
When encoding, `ContractCreationBits` field must be encoded before `TxTos`s. Therefore we have `(7 choose 2) * 5! = 2520` possible permutations.

### Deciding Permutation using Mainnet

Chose random channel and ran every possible permutations. Permutation `3, 0, 4, 1, 2, 6, 5` gave the best compression size reduction for single channel in mainnet.

Applied to mainnet and goerli
- Mainnet: Over 167 span batches, 158 got data size reduction. Others gained size. Compressed size sum before permutation: `157432813` byte. After permutation, we saved `59851` bytes, which is 0.038% reduction.
- Goerli: Over 2467 span batches, 1320 got data size reduction. Others gained size. Compressed size sum before permutation: `363703665` byte. After permutation, we gained `1017` bytes, which is 0.0002% gain.

### Deciding Permutation using Goerli

Chose random channel and ran every possible permutations. Permutation `0, 1, 2, 3, 4, 6, 5` gave the best compression size reduction for single channel in goerli.

Applied to mainnet and goerli
- Mainnet: Over 167 span batches, 124 got data size reduction. Others gained size. Compressed size sum before permutation: `157432813` byte. After permutation, we saved `14420` bytes, which is 0.00916% reduction.
- Goerli: Over 2467 span batches, 1524 got data size reduction. Others gained size. Compressed size sum before permutation: `363703665` byte. After permutation, we saved `2555` bytes, which is 0.0007% reduction.

### Thoughts

- It is very hard to choose the optimal permutation for satisfying every chain.
- Some permutations are definitely better than the original one(`0, 1, 2, 3, 4, 5, 6`), however its effect is very small.

Will experiment using other chains and finalize permutation to finalize data layout.





