### PR TITLE
Span Batch Type Unit Tests

### DIFF
--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -121,6 +121,7 @@ func (b *BatchData) decodeTyped(data []byte) error {
 	}
 }
 
+// NewSingularBatchData creates new BatchData with SingularBatch
 func NewSingularBatchData(singularBatch SingularBatch) *BatchData {
 	return &BatchData{
 		BatchType:     SingularBatchType,

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -19,7 +19,6 @@ import (
 
 func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
 	blockCount := uint64(1 + rng.Int()&0xFF)
-	//blockCount := uint64(10)
 	originBits := new(big.Int)
 	for i := 0; i < int(blockCount); i++ {
 		bit := uint(0)

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -1,8 +1,6 @@
 package derive
 
 import (
-	"bytes"
-	"errors"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -11,39 +9,15 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/trie"
 )
 
-// splitAndValidation splits single RawSpanBatch and initialize SingularBatch lists and validates parentCheck and l1OriginCheck
-func splitAndValidation(rawSpanBatch *RawSpanBatch, l1Origins []eth.L1BlockRef, safeL2Head eth.L2BlockRef, blockTime uint64, genesisTimestamp uint64, chainId *big.Int) ([]*SingularBatch, error) {
-	spanBatch, err := rawSpanBatch.derive(blockTime, genesisTimestamp, chainId)
-	if err != nil {
-		return nil, err
-	}
-	singularBatches, err := spanBatch.GetSingularBatches(l1Origins)
-	if err != nil {
-		return nil, err
-	}
-	// set only the first singularBatch's parent hash
-	singularBatches[0].ParentHash = safeL2Head.Hash
-	if !bytes.Equal(rawSpanBatch.parentCheck, safeL2Head.Hash.Bytes()[:20]) {
-		return nil, errors.New("parent hash mismatch")
-	}
-	l1OriginBlockHash := singularBatches[len(singularBatches)-1].EpochHash
-	if !bytes.Equal(rawSpanBatch.l1OriginCheck, l1OriginBlockHash[:20]) {
-		return nil, errors.New("l1 origin hash mismatch")
-	}
-	return singularBatches, nil
-}
-
 func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
-	//blockCount := uint64(1 + rng.Int()&0xFF)
-	blockCount := uint64(10)
+	blockCount := uint64(1 + rng.Int()&0xFF)
+	//blockCount := uint64(10)
 	originBits := new(big.Int)
 	for i := 0; i < int(blockCount); i++ {
 		bit := uint(0)
@@ -90,26 +64,61 @@ func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
 	return &rawSpanBatch
 }
 
-func RandomSingularBatch(rng *rand.Rand, txCount int) *SingularBatch {
-	l1Block := types.NewBlock(testutils.RandomHeader(rng),
-		nil, nil, nil, trie.NewStackTrie(nil))
-	l1InfoTx, err := L1InfoDeposit(0, eth.BlockToInfo(l1Block), eth.SystemConfig{}, testutils.RandomBool(rng))
-	if err != nil {
-		panic("L1InfoDeposit: " + err.Error())
+func RandomSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int) *SingularBatch {
+	signer := types.NewLondonSigner(chainID)
+	baseFee := big.NewInt(rng.Int63n(300_000_000_000))
+	txsEncoded := make([]hexutil.Bytes, 0, txCount)
+	// force each tx to have equal chainID
+	for i := 0; i < txCount; i++ {
+		tx := testutils.RandomTx(rng, baseFee, signer)
+		txEncoded, err := tx.MarshalBinary()
+		if err != nil {
+			panic("tx Marshal binary" + err.Error())
+		}
+		txsEncoded = append(txsEncoded, hexutil.Bytes(txEncoded))
 	}
-	l2Block, _ := testutils.RandomBlockPrependTxs(rng, txCount, types.NewTx(l1InfoTx))
-	singularBatch, _, err := BlockToSingularBatch(l2Block)
-	if err != nil {
-		panic("BlockToSingularBatch:" + err.Error())
+	return &SingularBatch{
+		ParentHash:   testutils.RandomHash(rng),
+		EpochNum:     rollup.Epoch(1 + rng.Int63n(100_000_000)),
+		EpochHash:    testutils.RandomHash(rng),
+		Timestamp:    uint64(rng.Int63n(2_000_000_000)),
+		Transactions: txsEncoded,
 	}
-	return singularBatch
+}
+
+func RandomValidConsecutiveSingularBatches(rng *rand.Rand, chainID *big.Int) []*SingularBatch {
+	blockCount := 2 + rng.Intn(128)
+	l2BlockTime := uint64(2)
+
+	var singularBatches []*SingularBatch
+	for i := 0; i < blockCount; i++ {
+		singularBatch := RandomSingularBatch(rng, 1+rng.Intn(8), chainID)
+		singularBatches = append(singularBatches, singularBatch)
+	}
+	l1BlockNum := rng.Uint64()
+	// make sure oldest timestamp is large enough
+	singularBatches[0].Timestamp += 256
+	for i := 0; i < blockCount; i++ {
+		originChangedBit := rng.Intn(2)
+		if originChangedBit == 1 {
+			l1BlockNum++
+			singularBatches[i].EpochHash = testutils.RandomHash(rng)
+		} else if i > 0 {
+			singularBatches[i].EpochHash = singularBatches[i-1].EpochHash
+		}
+		singularBatches[i].EpochNum = rollup.Epoch(l1BlockNum)
+		if i > 0 {
+			singularBatches[i].Timestamp = singularBatches[i-1].Timestamp + l2BlockTime
+		}
+	}
+	return singularBatches
 }
 
 func TestBatchRoundTrip(t *testing.T) {
 	rng := rand.New(rand.NewSource(0xdeadbeef))
 	blockTime := uint64(2)
 	genesisTimestamp := uint64(0)
-	chainId := new(big.Int).SetUint64(rng.Uint64())
+	chainID := new(big.Int).SetUint64(rng.Uint64())
 
 	batches := []*BatchData{
 		{
@@ -128,9 +137,9 @@ func TestBatchRoundTrip(t *testing.T) {
 				Transactions: []hexutil.Bytes{[]byte{0, 0, 0}, []byte{0x76, 0xfd, 0x7c}},
 			},
 		},
-		NewSingularBatchData(*RandomSingularBatch(rng, 5)),
-		NewSingularBatchData(*RandomSingularBatch(rng, 7)),
-		NewSpanBatchData(*RandomRawSpanBatch(rng, chainId)),
+		NewSingularBatchData(*RandomSingularBatch(rng, 5, chainID)),
+		NewSingularBatchData(*RandomSingularBatch(rng, 7, chainID)),
+		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
 	}
 
 	for i, batch := range batches {
@@ -140,175 +149,27 @@ func TestBatchRoundTrip(t *testing.T) {
 		err = dec.UnmarshalBinary(enc)
 		assert.NoError(t, err)
 		if dec.BatchType == SpanBatchType {
-			dec.RawSpanBatch.derive(blockTime, genesisTimestamp, chainId)
+			dec.RawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
 		}
 		assert.Equal(t, batch, &dec, "Batch not equal test case %v", i)
 	}
 }
 
-func TestSpanBatchMerge(t *testing.T) {
-	rng := rand.New(rand.NewSource(0x7331))
+func mockL1Origin(rng *rand.Rand, rawSpanBatch *RawSpanBatch, singularBatches []*SingularBatch) []eth.L1BlockRef {
+	safeHeadOrigin := testutils.RandomBlockRef(rng)
+	safeHeadOrigin.Hash = singularBatches[0].EpochHash
+	safeHeadOrigin.Number = uint64(singularBatches[0].EpochNum)
 
-	genesisTimeStamp := rng.Uint64()
-	l2BlockTime := uint64(2)
-	chainId := new(big.Int).SetUint64(rng.Uint64())
-
-	blockCount := 1 + rng.Intn(128)
-	var singularBatchs []*SingularBatch
-	for i := 0; i < blockCount; i++ {
-		singularBatch := RandomSingularBatch(rng, 1+rng.Intn(8))
-		singularBatchs = append(singularBatchs, singularBatch)
-	}
-	l1BlockNum := rng.Uint64()
-	for i := 0; i < blockCount; i++ {
-		if rng.Intn(2) == 1 {
-			l1BlockNum++
-		}
-		singularBatchs[i].EpochNum = rollup.Epoch(l1BlockNum)
-		if i == 0 {
-			continue
-		}
-		singularBatchs[i].Timestamp = singularBatchs[i-1].Timestamp + l2BlockTime
-	}
-
-	spanBatch := NewSpanBatch(singularBatchs)
-	rawSpanBatch, err := spanBatch.ToRawSpanBatch(uint(0), genesisTimeStamp, chainId)
-	assert.NoError(t, err)
-	assert.Equal(t, rawSpanBatch.parentCheck, singularBatchs[0].ParentHash.Bytes()[:20], "invalid parent check")
-	assert.Equal(t, rawSpanBatch.l1OriginCheck, singularBatchs[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
-	assert.Equal(t, rawSpanBatch.relTimestamp, singularBatchs[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
-	for i := 1; i < blockCount; i++ {
-		if rawSpanBatch.originBits.Bit(i) == 1 {
-			assert.True(t, singularBatchs[i].EpochNum == singularBatchs[i-1].EpochNum+1)
-		}
-	}
-	for i := 0; i < len(singularBatchs); i++ {
-		txCount := len(singularBatchs[i].Transactions)
-		assert.True(t, txCount == int(rawSpanBatch.blockTxCounts[i]))
-	}
-
-	// set invalid tx type to make tx unmarshaling fail
-	singularBatchs[0].Transactions[0][0] = 0x33
-	spanBatch = NewSpanBatch(singularBatchs)
-	_, err = spanBatch.ToRawSpanBatch(uint(0), genesisTimeStamp, chainId)
-	require.ErrorContains(t, err, "failed to decode tx")
-
-	//var singularBatchsEmpty []*SingularBatch
-	//spanBatch = NewSpanBatch(SpanBatchType, singularBatchsEmpty)
-	//_, err = spanBatch.ToRawSpanBatch(uint(0), genesisTimeStamp, chainId)
-	//require.ErrorContains(t, err, "cannot merge empty singularBatch list")
-}
-
-func prepareSplitBatch(rng *rand.Rand, l2BlockTime uint64, chainId *big.Int) ([]eth.L1BlockRef, *RawSpanBatch, eth.L2BlockRef, uint64) {
-	genesisTimeStamp := uint64(rng.Uint32())
-	rawSpanBatch := RandomRawSpanBatch(rng, chainId)
-	// recover parentHash
-	var parentHash []byte = append(rawSpanBatch.parentCheck, testutils.RandomData(rng, 12)...)
+	l1Origins := []eth.L1BlockRef{safeHeadOrigin}
 	originBitSum := uint64(0)
 	for i := 0; i < int(rawSpanBatch.blockCount); i++ {
 		if rawSpanBatch.originBits.Bit(i) == 1 {
+			l1Origin := testutils.NextRandomRef(rng, l1Origins[originBitSum])
 			originBitSum++
+			l1Origin.Hash = singularBatches[i].EpochHash
+			l1Origin.Number = uint64(singularBatches[i].EpochNum)
+			l1Origins = append(l1Origins, l1Origin)
 		}
 	}
-	safeHeadOrigin := testutils.RandomBlockRef(rng)
-	safeHeadOrigin.Number = rawSpanBatch.l1OriginNum - originBitSum
-	l1Origins := []eth.L1BlockRef{safeHeadOrigin}
-	for i := 0; i < int(originBitSum); i++ {
-		l1Origins = append(l1Origins, testutils.NextRandomRef(rng, l1Origins[i]))
-	}
-	rawSpanBatch.l1OriginNum = l1Origins[originBitSum].Number
-	rawSpanBatch.l1OriginCheck = l1Origins[originBitSum].Hash.Bytes()[:20]
-
-	safeL2head := testutils.RandomL2BlockRef(rng)
-	safeL2head.Hash = common.BytesToHash(parentHash)
-	safeL2head.L1Origin = safeHeadOrigin.ID()
-	// safeL2head must be parent so subtract l2BlockTime
-	safeL2head.Time = genesisTimeStamp + rawSpanBatch.relTimestamp - l2BlockTime
-
-	return l1Origins, rawSpanBatch, safeL2head, genesisTimeStamp
-}
-
-func TestSpanBatchSplit(t *testing.T) {
-	rng := rand.New(rand.NewSource(0xbab0bab0))
-
-	chainId := new(big.Int).SetUint64(rng.Uint64())
-	l2BlockTime := uint64(2)
-	l1Origins, rawSpanBatch, _, _ := prepareSplitBatch(rng, l2BlockTime, chainId)
-
-	spanBatch, err := rawSpanBatch.derive(l2BlockTime, genesisTimestamp, chainId)
-	assert.NoError(t, err)
-
-	singularBatchs, err := spanBatch.GetSingularBatches(l1Origins)
-	assert.NoError(t, err)
-
-	assert.True(t, len(singularBatchs) == int(rawSpanBatch.blockCount))
-
-	for i := 1; i < len(singularBatchs); i++ {
-		assert.True(t, singularBatchs[i].Timestamp == singularBatchs[i-1].Timestamp+l2BlockTime)
-	}
-
-	l1OriginBlockNumber := singularBatchs[0].EpochNum
-	for i := 1; i < len(singularBatchs); i++ {
-		if rawSpanBatch.originBits.Bit(i) == 1 {
-			l1OriginBlockNumber++
-		}
-		assert.True(t, singularBatchs[i].EpochNum == l1OriginBlockNumber)
-	}
-
-	for i := 0; i < len(singularBatchs); i++ {
-		txCount := len(singularBatchs[i].Transactions)
-		assert.True(t, txCount == int(rawSpanBatch.blockTxCounts[i]))
-	}
-}
-
-func TestSpanBatchSplitValidation(t *testing.T) {
-	rng := rand.New(rand.NewSource(0xcafe))
-
-	chainId := new(big.Int).SetUint64(rng.Uint64())
-	l2BlockTime := uint64(2)
-	l1Origins, rawSpanBatch, safeL2head, _ := prepareSplitBatch(rng, l2BlockTime, chainId)
-	// above datas are sane. Now contaminate with wrong datas
-
-	// set invalid l1 origin check
-	rawSpanBatch.l1OriginCheck = testutils.RandomData(rng, 20)
-	_, err := splitAndValidation(rawSpanBatch, l1Origins, safeL2head, l2BlockTime, genesisTimestamp, chainId)
-	require.ErrorContains(t, err, "l1 origin hash mismatch")
-
-	// set invalid parent check
-	rawSpanBatch.parentCheck = testutils.RandomData(rng, 20)
-	_, err = splitAndValidation(rawSpanBatch, l1Origins, safeL2head, l2BlockTime, genesisTimestamp, chainId)
-	require.ErrorContains(t, err, "parent hash mismatch")
-
-	// set invalid tx type to make tx marshaling fail
-	rawSpanBatch.txs.txDatas[0][0] = 0x33
-	_, err = splitAndValidation(rawSpanBatch, l1Origins, safeL2head, l2BlockTime, genesisTimestamp, chainId)
-	require.ErrorContains(t, err, types.ErrTxTypeNotSupported.Error())
-}
-
-func TestSpanBatchSplitMerge(t *testing.T) {
-	rng := rand.New(rand.NewSource(0x13371337))
-
-	chainId := new(big.Int).SetUint64(rng.Uint64())
-	l2BlockTime := uint64(2)
-	l1Origins, rawSpanBatch, safeL2head, genesisTimeStamp := prepareSplitBatch(rng, l2BlockTime, chainId)
-	originChangedBit := rawSpanBatch.originBits.Bit(0)
-	originBitSum := rawSpanBatch.l1OriginNum - safeL2head.L1Origin.Number
-
-	singularBatchs, err := splitAndValidation(rawSpanBatch, l1Origins, safeL2head, l2BlockTime, genesisTimeStamp, chainId)
-	require.NoError(t, err)
-
-	spanBatch := NewSpanBatch(singularBatchs)
-	rawSpanBatchMerged, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainId)
-	require.NoError(t, err)
-
-	assert.Equal(t, rawSpanBatch, rawSpanBatchMerged, "RawSpanBatch not equal")
-
-	// check invariants
-	//start_epoch_num = safe_l2_head.origin.block_number + (origin_changed_bit ? 1 : 0)
-	startEpochNum := uint64(singularBatchs[0].EpochNum)
-	assert.True(t, startEpochNum == safeL2head.L1Origin.Number+uint64(originChangedBit))
-	// end_epoch_num = safe_l2_head.origin.block_number + sum(origin_bits)
-	endEpochNum := rawSpanBatch.l1OriginNum
-	assert.True(t, endEpochNum == safeL2head.L1Origin.Number+originBitSum)
-	assert.True(t, endEpochNum == uint64(singularBatchs[len(singularBatchs)-1].EpochNum))
+	return l1Origins
 }

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -209,7 +209,6 @@ func TestBatchRoundTripRLP(t *testing.T) {
 	}
 
 	for i, batch := range batches {
-
 		var buf bytes.Buffer
 		err := batch.EncodeRLP(&buf)
 		assert.NoError(t, err)

--- a/op-node/rollup/derive/batch_tob_test.go
+++ b/op-node/rollup/derive/batch_tob_test.go
@@ -1,9 +1,11 @@
 package derive
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/testutils/fuzzerutils"
+	"github.com/ethereum/go-ethereum/rlp"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
 )
@@ -31,5 +33,35 @@ func FuzzBatchRoundTrip(f *testing.F) {
 
 		// Ensure the round trip encoding of batch data did not result in data loss
 		require.Equal(t, &batchData, &dec, "round trip batch encoding/decoding did not match original values")
+	})
+}
+
+// FuzzBatchRoundTripRLP executes a fuzz test similar to TestBatchRoundTripRLP, which tests that arbitrary BatchData will be
+// encoded and decoded without loss of its original values.
+func FuzzBatchRoundTripRLP(f *testing.F) {
+	f.Fuzz(func(t *testing.T, fuzzedData []byte) {
+		// Create our fuzzer wrapper to generate complex values
+		typeProvider := fuzz.NewFromGoFuzz(fuzzedData).NilChance(0).MaxDepth(10000).NumElements(0, 0x100).AllowUnexportedFields(true)
+		fuzzerutils.AddFuzzerFunctions(typeProvider)
+
+		// Create our batch data from fuzzed data
+		var batchData BatchData
+		typeProvider.Fuzz(&batchData)
+
+		// Encode our batch data
+		var buf bytes.Buffer
+		err := batchData.EncodeRLP(&buf)
+		require.NoError(t, err)
+		enc := buf.Bytes()
+
+		// Decode our encoded batch data
+		var dec BatchData
+		r := bytes.NewReader(enc)
+		s := rlp.NewStream(r, 0)
+		err = dec.DecodeRLP(s)
+		require.NoError(t, err)
+
+		// Ensure the round trip encoding of batch data did not result in data loss
+		require.Equal(t, &batchData, &dec, "round trip batch RLP encoding/decoding did not match original values")
 	})
 }

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -19,6 +19,11 @@ func frameSize(frame Frame) uint64 {
 
 const DerivationVersion0 = 0
 
+// MaxSpanBatchFieldSize is the maximum amount of bytes that will be read from
+// a span batch to decode span batch field. This value cannot be larger than
+// MaxRLPBytesPerChannel because single batch cannot be larger than channel size.
+const MaxSpanBatchFieldSize = 10_000_000
+
 // MaxChannelBankSize is the amount of memory space, in number of bytes,
 // till the bank is pruned by removing channels,
 // starting with the oldest channel.

--- a/op-node/rollup/derive/singular_batch_test.go
+++ b/op-node/rollup/derive/singular_batch_test.go
@@ -1,0 +1,1 @@
+package derive

--- a/op-node/rollup/derive/singular_batch_test.go
+++ b/op-node/rollup/derive/singular_batch_test.go
@@ -1,1 +1,25 @@
 package derive
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingularBatchForBatchInterface(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x543331))
+	chainID := big.NewInt(rng.Int63n(1000))
+	txCount := 1 + rng.Intn(8)
+
+	singularBatch := RandomSingularBatch(rng, txCount, chainID)
+	epochHash := singularBatch.EpochHash
+	parentHash := singularBatch.ParentHash
+
+	assert.Equal(t, SingularBatchType, singularBatch.GetBatchType())
+	assert.Equal(t, singularBatch.Timestamp, singularBatch.GetTimestamp())
+	assert.Equal(t, singularBatch.EpochNum, singularBatch.GetEpochNum())
+	assert.True(t, singularBatch.CheckOriginHash(epochHash))
+	assert.True(t, singularBatch.CheckParentHash(parentHash))
+}

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -48,6 +48,7 @@ type RawSpanBatch struct {
 }
 
 // decodeOriginBits parses data into bp.originBits
+// originbits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
 	originBitBufferLen := bp.blockCount / 8
 	if bp.blockCount%8 != 0 {
@@ -262,6 +263,7 @@ func (bp *spanBatchPrefix) encodePrefix(w io.Writer) error {
 }
 
 // encodeOriginBits encodes bp.originBits
+// originbits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) encodeOriginBits(w io.Writer) error {
 	originBitBufferLen := bp.blockCount / 8
 	if bp.blockCount%8 != 0 {

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -139,7 +139,6 @@ func (bp *spanBatchPrefix) decodePrefix(r *bytes.Reader) error {
 func (bp *spanBatchPayload) decodeBlockCount(r *bytes.Reader) error {
 	blockCount, err := binary.ReadUvarint(r)
 	bp.blockCount = blockCount
-	// TODO: check block count is not too large
 	if err != nil {
 		return fmt.Errorf("failed to read block count: %w", err)
 	}
@@ -156,7 +155,6 @@ func (bp *spanBatchPayload) decodeBlockTxCounts(r *bytes.Reader) error {
 	totalBlockTxCount := uint64(0)
 	for i := 0; i < int(bp.blockCount); i++ {
 		blockTxCount, err := binary.ReadUvarint(r)
-		// TODO: check blockTxCount is not too large
 		if err != nil {
 			return fmt.Errorf("failed to read block tx count: %w", err)
 		}

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -337,9 +337,8 @@ func (b *RawSpanBatch) derive(blockTime, genesisTimestamp uint64, chainID *big.I
 		}
 	}
 
-	b.txs.chainID = chainID
-	b.txs.recoverV()
-	fullTxs, err := b.txs.fullTxs()
+	b.txs.recoverV(chainID)
+	fullTxs, err := b.txs.fullTxs(chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -159,7 +159,7 @@ func (bp *spanBatchPayload) decodeBlockTxCounts(r *bytes.Reader) error {
 }
 
 // decodePayload parses data into b.spanBatchPayload
-func (b *RawSpanBatch) decodePayload(r *bytes.Reader) error {
+func (b *spanBatchPayload) decodePayload(r *bytes.Reader) error {
 	if b.txs == nil {
 		b.txs = &spanBatchTxs{}
 	}
@@ -281,7 +281,7 @@ func (bp *spanBatchPayload) encodeBlockTxCounts(w io.Writer) error {
 	return nil
 }
 
-func (b *RawSpanBatch) encodePayload(w io.Writer) error {
+func (b *spanBatchPayload) encodePayload(w io.Writer) error {
 	if err := b.encodeBlockCount(w); err != nil {
 		return err
 	}

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -618,6 +618,9 @@ func ReadTxData(r *bytes.Reader) ([]byte, int, error) {
 	kind, _, err := s.Kind()
 	switch {
 	case err != nil:
+		if errors.Is(err, rlp.ErrValueTooLarge) {
+			return nil, 0, ErrTooBigSpanBatchFieldSize
+		}
 		return nil, 0, fmt.Errorf("failed to read tx RLP prefix: %w", err)
 	case kind == rlp.List:
 		if txPayload, err = s.Raw(); err != nil {

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -48,7 +48,7 @@ type RawSpanBatch struct {
 }
 
 // decodeOriginBits parses data into bp.originBits
-// originbits is bitlist right-padded to a multiple of 8 bits
+// originBits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
 	originBitBufferLen := bp.blockCount / 8
 	if bp.blockCount%8 != 0 {
@@ -263,7 +263,7 @@ func (bp *spanBatchPrefix) encodePrefix(w io.Writer) error {
 }
 
 // encodeOriginBits encodes bp.originBits
-// originbits is bitlist right-padded to a multiple of 8 bits
+// originBits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) encodeOriginBits(w io.Writer) error {
 	originBitBufferLen := bp.blockCount / 8
 	if bp.blockCount%8 != 0 {

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -529,6 +529,9 @@ func (b *SpanBatch) GetSingularBatches(l1Origins []eth.L1BlockRef) ([]*SingularB
 
 // NewSpanBatch converts given singularBatches into spanBatchElements, and creates a new SpanBatch.
 func NewSpanBatch(singularBatches []*SingularBatch) *SpanBatch {
+	if len(singularBatches) == 0 {
+		return &SpanBatch{}
+	}
 	spanBatch := SpanBatch{
 		parentCheck:   singularBatches[0].ParentHash.Bytes()[:20],
 		l1OriginCheck: singularBatches[len(singularBatches)-1].EpochHash.Bytes()[:20],

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -327,7 +327,7 @@ func (b *RawSpanBatch) encodeBytes() ([]byte, error) {
 
 // derive converts RawSpanBatch into SpanBatch, which has a list of spanBatchElement.
 // We need chain config constants to derive values for making payload attributes.
-func (b *RawSpanBatch) derive(blockTime, genesisTimestamp uint64, chainId *big.Int) (*SpanBatch, error) {
+func (b *RawSpanBatch) derive(blockTime, genesisTimestamp uint64, chainID *big.Int) (*SpanBatch, error) {
 	blockOriginNums := make([]uint64, b.blockCount)
 	l1OriginBlockNumber := b.l1OriginNum
 	for i := int(b.blockCount) - 1; i >= 0; i-- {
@@ -337,7 +337,7 @@ func (b *RawSpanBatch) derive(blockTime, genesisTimestamp uint64, chainId *big.I
 		}
 	}
 
-	b.txs.chainID = chainId
+	b.txs.chainID = chainID
 	b.txs.recoverV()
 	fullTxs, err := b.txs.fullTxs()
 	if err != nil {
@@ -457,7 +457,7 @@ func (b *SpanBatch) AppendSingularBatch(singularBatch *SingularBatch) {
 }
 
 // ToRawSpanBatch merges SingularBatch List and initialize single RawSpanBatch
-func (b *SpanBatch) ToRawSpanBatch(originChangedBit uint, genesisTimestamp uint64, chainId *big.Int) (*RawSpanBatch, error) {
+func (b *SpanBatch) ToRawSpanBatch(originChangedBit uint, genesisTimestamp uint64, chainID *big.Int) (*RawSpanBatch, error) {
 	if len(b.batches) == 0 {
 		return nil, errors.New("cannot merge empty singularBatch list")
 	}
@@ -496,7 +496,7 @@ func (b *SpanBatch) ToRawSpanBatch(originChangedBit uint, genesisTimestamp uint6
 		}
 	}
 	raw.blockTxCounts = blockTxCounts
-	stxs, err := newSpanBatchTxs(txs, chainId)
+	stxs, err := newSpanBatchTxs(txs, chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -553,15 +553,15 @@ func NewSpanBatch(singularBatches []*SingularBatch) *SpanBatch {
 type SpanBatchBuilder struct {
 	parentEpoch      uint64
 	genesisTimestamp uint64
-	chainId          *big.Int
+	chainID          *big.Int
 	spanBatch        *SpanBatch
 }
 
-func NewSpanBatchBuilder(parentEpoch uint64, genesisTimestamp uint64, chainId *big.Int) *SpanBatchBuilder {
+func NewSpanBatchBuilder(parentEpoch uint64, genesisTimestamp uint64, chainID *big.Int) *SpanBatchBuilder {
 	return &SpanBatchBuilder{
 		parentEpoch:      parentEpoch,
 		genesisTimestamp: genesisTimestamp,
-		chainId:          chainId,
+		chainID:          chainID,
 		spanBatch:        &SpanBatch{},
 	}
 }
@@ -575,7 +575,7 @@ func (b *SpanBatchBuilder) GetRawSpanBatch() (*RawSpanBatch, error) {
 	if uint64(b.spanBatch.GetEpochNum()) != b.parentEpoch {
 		originChangedBit = 1
 	}
-	raw, err := b.spanBatch.ToRawSpanBatch(uint(originChangedBit), b.genesisTimestamp, b.chainId)
+	raw, err := b.spanBatch.ToRawSpanBatch(uint(originChangedBit), b.genesisTimestamp, b.chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -39,15 +39,10 @@ func TestSpanBatchOriginBits(t *testing.T) {
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
 
-	originBits := rawSpanBatch.originBits
 	blockCount := rawSpanBatch.blockCount
 
-	var sb RawSpanBatch
-	sb.blockCount = blockCount
-	sb.originBits = originBits
-
 	var buf bytes.Buffer
-	err := sb.encodeOriginBits(&buf)
+	err := rawSpanBatch.encodeOriginBits(&buf)
 	assert.NoError(t, err)
 
 	// originBit field is fixed length: single bit
@@ -58,13 +53,13 @@ func TestSpanBatchOriginBits(t *testing.T) {
 	assert.Equal(t, buf.Len(), int(originBitBufferLen))
 
 	result := buf.Bytes()
-	sb.originBits = nil
-
+	var sb RawSpanBatch
+	sb.blockCount = blockCount
 	r := bytes.NewReader(result)
 	err = sb.decodeOriginBits(r)
 	assert.NoError(t, err)
 
-	assert.Equal(t, originBits, sb.originBits)
+	assert.Equal(t, rawSpanBatch.originBits, sb.originBits)
 }
 
 func TestSpanBatchPrefix(t *testing.T) {

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -1,0 +1,1 @@
+package derive

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -386,6 +386,7 @@ func TestSpanBatchToSingularBatch(t *testing.T) {
 		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
 		safeL2Head := testutils.RandomL2BlockRef(rng)
 		safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+		safeL2Head.Time = singularBatches[0].Timestamp - 2
 		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
 
 		spanBatch := NewSpanBatch(singularBatches)
@@ -395,7 +396,7 @@ func TestSpanBatchToSingularBatch(t *testing.T) {
 
 		l1Origins := mockL1Origin(rng, rawSpanBatch, singularBatches)
 
-		singularBatches2, err := spanBatch.GetSingularBatches(l1Origins)
+		singularBatches2, err := spanBatch.GetSingularBatches(l1Origins, safeL2Head)
 		assert.NoError(t, err)
 
 		// GetSingularBatches does not fill in parent hash of singular batches

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -14,11 +14,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSpanBatchInterface(t *testing.T) {
-	// rng := rand.New(rand.NewSource(0x54321))
-	// chainID := big.NewInt(rng.Int63n(1000))
-	// signer := types.NewLondonSigner(chainID)
+func TestSpanBatchForBatchInterface(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5432177))
+	chainID := big.NewInt(rng.Int63n(1000))
 
+	singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+	blockCount := len(singularBatches)
+	safeL2Head := testutils.RandomL2BlockRef(rng)
+	safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+
+	spanBatch := NewSpanBatch(singularBatches)
+
+	// check interface method implementations except logging
+	assert.Equal(t, SpanBatchType, spanBatch.GetBatchType())
+	assert.Equal(t, singularBatches[0].Timestamp, spanBatch.GetTimestamp())
+	assert.Equal(t, singularBatches[0].EpochNum, spanBatch.GetEpochNum())
+	assert.True(t, spanBatch.CheckOriginHash(singularBatches[blockCount-1].EpochHash))
+	assert.True(t, spanBatch.CheckParentHash(singularBatches[0].ParentHash))
 }
 
 func TestSpanBatchOriginBits(t *testing.T) {

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -187,8 +187,7 @@ func TestSpanBatchPayload(t *testing.T) {
 	err = sb.decodePayload(r)
 	assert.NoError(t, err)
 
-	sb.txs.chainID = chainID
-	sb.txs.recoverV()
+	sb.txs.recoverV(chainID)
 
 	assert.Equal(t, rawSpanBatch.spanBatchPayload, sb.spanBatchPayload)
 }
@@ -249,12 +248,11 @@ func TestSpanBatchTxs(t *testing.T) {
 	var sb RawSpanBatch
 	sb.txs = &spanBatchTxs{}
 
-	sb.txs.chainID = chainID
 	sb.txs.totalBlockTxCount = rawSpanBatch.txs.totalBlockTxCount
 	err = sb.txs.decode(r)
 	assert.NoError(t, err)
 
-	sb.txs.recoverV()
+	sb.txs.recoverV(chainID)
 
 	assert.Equal(t, rawSpanBatch.txs, sb.txs)
 }
@@ -270,13 +268,12 @@ func TestSpanBatchRoundTrip(t *testing.T) {
 
 	var sb RawSpanBatch
 	sb.txs = &spanBatchTxs{}
-	sb.txs.chainID = chainID
 	sb.txs.totalBlockTxCount = rawSpanBatch.txs.totalBlockTxCount
 
 	err = sb.decodeBytes(result)
 	assert.NoError(t, err)
 
-	sb.txs.recoverV()
+	sb.txs.recoverV(chainID)
 
 	assert.Equal(t, rawSpanBatch, &sb)
 }
@@ -503,7 +500,7 @@ func TestSpanBatchMaxTxData(t *testing.T) {
 	rng := rand.New(rand.NewSource(0x177288))
 
 	invalidTx := types.NewTx(&types.DynamicFeeTx{
-		Data: testutils.RandomData(rng, MaxSpanBatchFieldSize + 1),
+		Data: testutils.RandomData(rng, MaxSpanBatchFieldSize+1),
 	})
 
 	txEncoded, err := invalidTx.MarshalBinary()

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -235,16 +235,15 @@ func TestSpanBatchTxs(t *testing.T) {
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
 
 	var buf bytes.Buffer
-	err := rawSpanBatch.txs.encode(&buf)
+	err := rawSpanBatch.encodeTxs(&buf)
 	assert.NoError(t, err)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
-	sb.txs = &spanBatchTxs{}
 
-	sb.txs.totalBlockTxCount = rawSpanBatch.txs.totalBlockTxCount
-	err = sb.txs.decode(r)
+	sb.blockTxCounts = rawSpanBatch.blockTxCounts
+	err = sb.decodeTxs(r)
 	assert.NoError(t, err)
 
 	sb.txs.recoverV(chainID)
@@ -262,9 +261,6 @@ func TestSpanBatchRoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 
 	var sb RawSpanBatch
-	sb.txs = &spanBatchTxs{}
-	sb.txs.totalBlockTxCount = rawSpanBatch.txs.totalBlockTxCount
-
 	err = sb.decodeBytes(result)
 	assert.NoError(t, err)
 

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -1,1 +1,500 @@
 package derive
+
+import (
+	"bytes"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanBatchInterface(t *testing.T) {
+	// rng := rand.New(rand.NewSource(0x54321))
+	// chainID := big.NewInt(rng.Int63n(1000))
+	// signer := types.NewLondonSigner(chainID)
+
+}
+
+func TestSpanBatchOriginBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77665544))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	originBits := rawSpanBatch.originBits
+	blockCount := rawSpanBatch.blockCount
+
+	var sb RawSpanBatch
+	sb.blockCount = blockCount
+	sb.originBits = originBits
+
+	var buf bytes.Buffer
+	err := sb.encodeOriginBits(&buf)
+	assert.NoError(t, err)
+
+	// originBit field is fixed length: single bit
+	originBitBufferLen := blockCount / 8
+	if blockCount%8 != 0 {
+		originBitBufferLen++
+	}
+	assert.Equal(t, buf.Len(), int(originBitBufferLen))
+
+	result := buf.Bytes()
+	sb.originBits = nil
+
+	r := bytes.NewReader(result)
+	err = sb.decodeOriginBits(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, originBits, sb.originBits)
+}
+
+func TestSpanBatchPrefix(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x44775566))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	// only compare prefix
+	rawSpanBatch.spanBatchPayload = spanBatchPayload{}
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodePrefix(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodePrefix(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch, &sb)
+}
+
+func TestSpanBatchRelTimestamp(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x44775566))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeRelTimestamp(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeRelTimestamp(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.relTimestamp, sb.relTimestamp)
+}
+
+func TestSpanBatchL1OriginNum(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556688))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeL1OriginNum(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeL1OriginNum(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.l1OriginNum, sb.l1OriginNum)
+}
+
+func TestSpanBatchParentCheck(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556689))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeParentCheck(&buf)
+	assert.NoError(t, err)
+
+	// parent check field is fixed length: 20 bytes
+	assert.Equal(t, buf.Len(), 20)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeParentCheck(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.parentCheck, sb.parentCheck)
+}
+
+func TestSpanBatchL1OriginCheck(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556690))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeL1OriginCheck(&buf)
+	assert.NoError(t, err)
+
+	// l1 origin check field is fixed length: 20 bytes
+	assert.Equal(t, buf.Len(), 20)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeL1OriginCheck(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.l1OriginCheck, sb.l1OriginCheck)
+}
+
+func TestSpanBatchPayload(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodePayload(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+
+	err = sb.decodePayload(r)
+	assert.NoError(t, err)
+
+	sb.txs.chainID = chainID
+	sb.txs.recoverV()
+
+	assert.Equal(t, rawSpanBatch.spanBatchPayload, sb.spanBatchPayload)
+}
+
+func TestSpanBatchBlockCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeBlockCount(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+
+	err = sb.decodeBlockCount(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.blockCount, sb.blockCount)
+}
+
+func TestSpanBatchBlockTxCounts(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556692))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeBlockTxCounts(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+
+	sb.blockCount = rawSpanBatch.blockCount
+	err = sb.decodeBlockTxCounts(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.blockTxCounts, sb.blockTxCounts)
+}
+
+func TestSpanBatchTxs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556693))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.txs.encode(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	sb.txs = &spanBatchTxs{}
+
+	sb.txs.chainID = chainID
+	sb.txs.totalBlockTxCount = rawSpanBatch.txs.totalBlockTxCount
+	err = sb.txs.decode(r)
+	assert.NoError(t, err)
+
+	sb.txs.recoverV()
+
+	assert.Equal(t, rawSpanBatch.txs, sb.txs)
+}
+
+func TestSpanBatchRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556694))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	result, err := rawSpanBatch.encodeBytes()
+	assert.NoError(t, err)
+
+	var sb RawSpanBatch
+	sb.txs = &spanBatchTxs{}
+	sb.txs.chainID = chainID
+	sb.txs.totalBlockTxCount = rawSpanBatch.txs.totalBlockTxCount
+
+	err = sb.decodeBytes(result)
+	assert.NoError(t, err)
+
+	sb.txs.recoverV()
+
+	assert.Equal(t, rawSpanBatch, &sb)
+}
+
+func TestSpanBatchDerive(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xbab0bab0))
+
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+	l2BlockTime := uint64(2)
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		safeL2Head := testutils.RandomL2BlockRef(rng)
+		safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
+
+		spanBatch := NewSpanBatch(singularBatches)
+		originChangedBit := uint(originChangedBit)
+		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		spanBatchDerived, err := rawSpanBatch.derive(l2BlockTime, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		blockCount := len(singularBatches)
+		assert.Equal(t, safeL2Head.Hash.Bytes()[:20], spanBatchDerived.parentCheck)
+		assert.Equal(t, singularBatches[blockCount-1].Epoch().Hash.Bytes()[:20], spanBatchDerived.l1OriginCheck)
+		assert.Equal(t, len(singularBatches), int(rawSpanBatch.blockCount))
+
+		for i := 1; i < len(singularBatches); i++ {
+			assert.Equal(t, spanBatchDerived.batches[i].Timestamp, spanBatchDerived.batches[i-1].Timestamp+l2BlockTime)
+		}
+
+		for i := 0; i < len(singularBatches); i++ {
+			assert.Equal(t, singularBatches[i].EpochNum, spanBatchDerived.batches[i].EpochNum)
+			assert.Equal(t, singularBatches[i].Timestamp, spanBatchDerived.batches[i].Timestamp)
+			assert.Equal(t, singularBatches[i].Transactions, spanBatchDerived.batches[i].Transactions)
+		}
+	}
+}
+
+func TestSpanBatchAppend(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x44337711))
+
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+	// initialize empty span batch
+	spanBatch := NewSpanBatch([]*SingularBatch{})
+
+	L := 2
+	for i := 0; i < L; i++ {
+		spanBatch.AppendSingularBatch(singularBatches[i])
+	}
+	// initialize with two singular batches
+	spanBatch2 := NewSpanBatch(singularBatches[:L])
+
+	assert.Equal(t, spanBatch, spanBatch2)
+}
+
+func TestSpanBatchMerge(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x73314433))
+
+	genesisTimeStamp := rng.Uint64()
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		blockCount := len(singularBatches)
+
+		spanBatch := NewSpanBatch(singularBatches)
+		originChangedBit := uint(originChangedBit)
+		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		// check span batch prefix
+		assert.Equal(t, rawSpanBatch.relTimestamp, singularBatches[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
+		assert.Equal(t, rollup.Epoch(rawSpanBatch.l1OriginNum), singularBatches[blockCount-1].EpochNum)
+		assert.Equal(t, rawSpanBatch.parentCheck, singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
+		assert.Equal(t, rawSpanBatch.l1OriginCheck, singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
+
+		// check span batch payload
+		assert.Equal(t, int(rawSpanBatch.blockCount), len(singularBatches))
+		assert.Equal(t, rawSpanBatch.originBits.Bit(0), originChangedBit)
+		for i := 1; i < blockCount; i++ {
+			if rawSpanBatch.originBits.Bit(i) == 1 {
+				assert.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum+1)
+			} else {
+				assert.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum)
+			}
+		}
+		for i := 0; i < len(singularBatches); i++ {
+			txCount := len(singularBatches[i].Transactions)
+			assert.Equal(t, txCount, int(rawSpanBatch.blockTxCounts[i]))
+		}
+
+		// check invariants
+		endEpochNum := rawSpanBatch.l1OriginNum
+		assert.Equal(t, endEpochNum, uint64(singularBatches[blockCount-1].EpochNum))
+
+		// we do not check txs field because it has to be derived to be compared
+	}
+}
+
+func TestSpanBatchToSingularBatch(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xbab0bab1))
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		safeL2Head := testutils.RandomL2BlockRef(rng)
+		safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
+
+		spanBatch := NewSpanBatch(singularBatches)
+		originChangedBit := uint(originChangedBit)
+		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		l1Origins := mockL1Origin(rng, rawSpanBatch, singularBatches)
+
+		singularBatches2, err := spanBatch.GetSingularBatches(l1Origins)
+		assert.NoError(t, err)
+
+		// GetSingularBatches does not fill in parent hash of singular batches
+		// empty out parent hash for comparison
+		for i := 0; i < len(singularBatches); i++ {
+			singularBatches[i].ParentHash = common.Hash{}
+		}
+		// check parent hash is empty
+		for i := 0; i < len(singularBatches2); i++ {
+			assert.Equal(t, singularBatches2[i].ParentHash, common.Hash{})
+		}
+
+		assert.Equal(t, singularBatches, singularBatches2)
+	}
+}
+
+func TestSpanBatchReadTxData(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x109550))
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	txCount := 64
+
+	signer := types.NewLondonSigner(chainID)
+	var rawTxs [][]byte
+	var txs []*types.Transaction
+	m := make(map[byte]int)
+	for i := 0; i < txCount; i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		m[tx.Type()] += 1
+		rawTx, err := tx.MarshalBinary()
+		assert.NoError(t, err)
+		rawTxs = append(rawTxs, rawTx)
+		txs = append(txs, tx)
+	}
+
+	for i := 0; i < txCount; i++ {
+		r := bytes.NewReader(rawTxs[i])
+		_, txType, err := ReadTxData(r)
+		assert.NoError(t, err)
+		assert.Equal(t, int(txs[i].Type()), txType)
+	}
+	// make sure every tx type is tested
+	assert.Positive(t, m[types.LegacyTxType])
+	assert.Positive(t, m[types.AccessListTxType])
+	assert.Positive(t, m[types.DynamicFeeTxType])
+}
+
+func TestSpanBatchReadTxDataInvalid(t *testing.T) {
+	dummy, err := rlp.EncodeToBytes("dummy")
+	assert.NoError(t, err)
+
+	// test non list rlp decoding
+	r := bytes.NewReader(dummy)
+	_, _, err = ReadTxData(r)
+	assert.ErrorContains(t, err, "tx RLP prefix type must be list")
+}
+
+func TestSpanBatchMaxTxData(t *testing.T) {
+
+}
+
+func TestSpanBatchBuilder(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xbab1bab1))
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		safeL2Head := testutils.RandomL2BlockRef(rng)
+		if originChangedBit == 0 {
+			safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+		}
+		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
+
+		parentEpoch := uint64(singularBatches[0].EpochNum)
+		if originChangedBit == 1 {
+			parentEpoch -= 1
+		}
+		spanBatchBuilder := NewSpanBatchBuilder(parentEpoch, genesisTimeStamp, chainID)
+
+		assert.Equal(t, 0, spanBatchBuilder.GetBlockCount())
+
+		for i := 0; i < len(singularBatches); i++ {
+			spanBatchBuilder.AppendSingularBatch(singularBatches[i])
+			assert.Equal(t, i+1, spanBatchBuilder.GetBlockCount())
+			assert.Equal(t, singularBatches[0].ParentHash.Bytes()[:20], spanBatchBuilder.spanBatch.parentCheck)
+			assert.Equal(t, singularBatches[i].EpochHash.Bytes()[:20], spanBatchBuilder.spanBatch.l1OriginCheck)
+		}
+
+		rawSpanBatch, err := spanBatchBuilder.GetRawSpanBatch()
+		assert.NoError(t, err)
+
+		// compare with rawSpanBatch not using spanBatchBuilder
+		spanBatch := NewSpanBatch(singularBatches)
+		originChangedBit := uint(originChangedBit)
+		rawSpanBatch2, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		assert.Equal(t, rawSpanBatch2, rawSpanBatch)
+
+		spanBatchBuilder.Reset()
+		assert.Equal(t, 0, spanBatchBuilder.GetBlockCount())
+	}
+}
+
+func TestSpanBatchMaxBlockCount(t *testing.T) {
+
+}
+
+func TestSpanBatchMaxBlockTxCount(t *testing.T) {
+
+}

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -456,10 +456,6 @@ func TestSpanBatchReadTxDataInvalid(t *testing.T) {
 	assert.ErrorContains(t, err, "tx RLP prefix type must be list")
 }
 
-func TestSpanBatchMaxTxData(t *testing.T) {
-
-}
-
 func TestSpanBatchBuilder(t *testing.T) {
 	rng := rand.New(rand.NewSource(0xbab1bab1))
 	chainID := new(big.Int).SetUint64(rng.Uint64())
@@ -503,10 +499,27 @@ func TestSpanBatchBuilder(t *testing.T) {
 	}
 }
 
-func TestSpanBatchMaxBlockCount(t *testing.T) {
+func TestSpanBatchMaxTxData(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x177288))
 
+	invalidTx := types.NewTx(&types.DynamicFeeTx{
+		Data: testutils.RandomData(rng, MaxSpanBatchFieldSize + 1),
+	})
+
+	txEncoded, err := invalidTx.MarshalBinary()
+	assert.NoError(t, err)
+
+	r := bytes.NewReader(txEncoded)
+	_, _, err = ReadTxData(r)
+
+	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
 }
 
-func TestSpanBatchMaxBlockTxCount(t *testing.T) {
+func TestSpanBatchMaxOriginBitsLength(t *testing.T) {
+	var sb RawSpanBatch
+	sb.blockCount = 0xFFFFFFFFFFFFFFFF
 
+	r := bytes.NewReader([]byte{})
+	err := sb.decodeOriginBits(r)
+	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
 }

--- a/op-node/rollup/derive/span_batch_tx.go
+++ b/op-node/rollup/derive/span_batch_tx.go
@@ -221,6 +221,7 @@ func (tx *spanBatchTx) convertToFullTx(nonce, gas uint64, to *common.Address, ch
 	return types.NewTx(inner), nil
 }
 
+// newSpanBatchTx converts types.Transaction to spanBatchTx
 func newSpanBatchTx(tx types.Transaction) (*spanBatchTx, error) {
 	var inner spanBatchTxData
 	switch tx.Type() {

--- a/op-node/rollup/derive/span_batch_tx_test.go
+++ b/op-node/rollup/derive/span_batch_tx_test.go
@@ -1,1 +1,148 @@
 package derive
+
+import (
+	"bytes"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanBatchTxConvert(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1331))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	m := make(map[byte]int)
+	for i := 0; i < 32; i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		m[tx.Type()] += 1
+		v, r, s := tx.RawSignatureValues()
+		sbtx, err := newSpanBatchTx(*tx)
+		assert.NoError(t, err)
+
+		tx2, err := sbtx.convertToFullTx(tx.Nonce(), tx.Gas(), tx.To(), chainID, v, r, s)
+		assert.NoError(t, err)
+
+		// compare after marshal because we only need inner field of transaction
+		txEncoded, err := tx.MarshalBinary()
+		assert.NoError(t, err)
+		tx2Encoded, err := tx2.MarshalBinary()
+		assert.NoError(t, err)
+
+		assert.Equal(t, txEncoded, tx2Encoded)
+	}
+	// make sure every tx type is tested
+	assert.Positive(t, m[types.LegacyTxType])
+	assert.Positive(t, m[types.AccessListTxType])
+	assert.Positive(t, m[types.DynamicFeeTxType])
+}
+
+func TestSpanBatchTxRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1332))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	m := make(map[byte]int)
+	for i := 0; i < 32; i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		m[tx.Type()] += 1
+		sbtx, err := newSpanBatchTx(*tx)
+		assert.NoError(t, err)
+
+		sbtxEncoded, err := sbtx.MarshalBinary()
+		assert.NoError(t, err)
+
+		var sbtx2 spanBatchTx
+		sbtx2.UnmarshalBinary(sbtxEncoded)
+
+		assert.Equal(t, sbtx, &sbtx2)
+	}
+	// make sure every tx type is tested
+	assert.Positive(t, m[types.LegacyTxType])
+	assert.Positive(t, m[types.AccessListTxType])
+	assert.Positive(t, m[types.DynamicFeeTxType])
+}
+
+func TestSpanBatchTxRoundTripRLP(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1333))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	m := make(map[byte]int)
+	for i := 0; i < 32; i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		m[tx.Type()] += 1
+		sbtx, err := newSpanBatchTx(*tx)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = sbtx.EncodeRLP(&buf)
+		assert.NoError(t, err)
+
+		result := buf.Bytes()
+		var sbtx2 spanBatchTx
+		r := bytes.NewReader(result)
+		rlpReader := rlp.NewStream(r, 0)
+		sbtx2.DecodeRLP(rlpReader)
+
+		assert.Equal(t, sbtx, &sbtx2)
+	}
+	// make sure every tx type is tested
+	assert.Positive(t, m[types.LegacyTxType])
+	assert.Positive(t, m[types.AccessListTxType])
+	assert.Positive(t, m[types.DynamicFeeTxType])
+}
+
+type spanBatchDummyTxData struct{}
+
+func (txData *spanBatchDummyTxData) txType() byte { return types.DepositTxType }
+func TestSpanBatchTxInvalidTxType(t *testing.T) {
+	// span batch never contain deposit tx
+	depositTx := types.NewTx(&types.DepositTx{})
+	_, err := newSpanBatchTx(*depositTx)
+	assert.ErrorContains(t, err, "invalid tx type")
+
+	var sbtx spanBatchTx
+	sbtx.inner = &spanBatchDummyTxData{}
+	_, err = sbtx.convertToFullTx(0, 0, nil, nil, nil, nil, nil)
+	assert.ErrorContains(t, err, "invalid tx type")
+}
+
+func TestSpanBatchTxDecodeInvalid(t *testing.T) {
+	var sbtx spanBatchTx
+	_, err := sbtx.decodeTyped([]byte{})
+	assert.EqualError(t, err, "typed transaction too short")
+
+	tx := types.NewTx(&types.LegacyTx{})
+	txEncoded, err := tx.MarshalBinary()
+	assert.NoError(t, err)
+
+	// legacy tx is not typed tx
+	_, err = sbtx.decodeTyped(txEncoded)
+	assert.EqualError(t, err, types.ErrTxTypeNotSupported.Error())
+
+	tx2 := types.NewTx(&types.AccessListTx{})
+	tx2Encoded, err := tx2.MarshalBinary()
+	assert.NoError(t, err)
+
+	tx2Encoded[0] = types.DynamicFeeTxType
+	_, err = sbtx.decodeTyped(tx2Encoded)
+	assert.ErrorContains(t, err, "failed to decode spanBatchDynamicFeeTxData")
+
+	tx3 := types.NewTx(&types.DynamicFeeTx{})
+	tx3Encoded, err := tx3.MarshalBinary()
+	assert.NoError(t, err)
+
+	tx3Encoded[0] = types.AccessListTxType
+	_, err = sbtx.decodeTyped(tx3Encoded)
+	assert.ErrorContains(t, err, "failed to decode spanBatchAccessListTxData")
+
+	invalidLegacyTxDecoded := []byte{0xFF, 0xFF}
+	err = sbtx.UnmarshalBinary(invalidLegacyTxDecoded)
+	assert.ErrorContains(t, err, "failed to decode spanBatchLegacyTxData")
+}

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -225,26 +225,26 @@ func (btx *spanBatchTxs) decodeTxSigsRS(r *bytes.Reader) error {
 }
 
 func (btx *spanBatchTxs) decodeTxNonces(r *bytes.Reader) error {
-	txNonces := make([]uint64, btx.totalBlockTxCount)
+	var txNonces []uint64
 	for i := 0; i < int(btx.totalBlockTxCount); i++ {
 		txNonce, err := binary.ReadUvarint(r)
 		if err != nil {
 			return fmt.Errorf("failed to read tx nonce: %w", err)
 		}
-		txNonces[i] = txNonce
+		txNonces = append(txNonces, txNonce)
 	}
 	btx.txNonces = txNonces
 	return nil
 }
 
 func (btx *spanBatchTxs) decodeTxGases(r *bytes.Reader) error {
-	txGases := make([]uint64, btx.totalBlockTxCount)
+	var txGases []uint64
 	for i := 0; i < int(btx.totalBlockTxCount); i++ {
 		txGas, err := binary.ReadUvarint(r)
 		if err != nil {
 			return fmt.Errorf("failed to read tx gas: %w", err)
 		}
-		txGases[i] = txGas
+		txGases = append(txGases, txGas)
 	}
 	btx.txGases = txGases
 	return nil

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -413,7 +413,7 @@ func convertVToYParity(v uint64, txType int) uint {
 	return yParityBit
 }
 
-func newSpanBatchTxs(txs [][]byte, chainId *big.Int) (*spanBatchTxs, error) {
+func newSpanBatchTxs(txs [][]byte, chainID *big.Int) (*spanBatchTxs, error) {
 	totalBlockTxCount := uint64(len(txs))
 	var txSigs []spanBatchSignature
 	var txTos []common.Address
@@ -459,7 +459,7 @@ func newSpanBatchTxs(txs [][]byte, chainId *big.Int) (*spanBatchTxs, error) {
 	}
 	return &spanBatchTxs{
 		totalBlockTxCount:    totalBlockTxCount,
-		chainID:              chainId,
+		chainID:              chainID,
 		contractCreationBits: contractCreationBits,
 		yParityBits:          yParityBits,
 		txSigs:               txSigs,

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -204,7 +204,7 @@ func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
 }
 
 func (btx *spanBatchTxs) decodeTxSigsRS(r *bytes.Reader) error {
-	txSigs := make([]spanBatchSignature, btx.totalBlockTxCount)
+	var txSigs []spanBatchSignature
 	var sigBuffer [32]byte
 	for i := 0; i < int(btx.totalBlockTxCount); i++ {
 		var txSig spanBatchSignature
@@ -218,7 +218,7 @@ func (btx *spanBatchTxs) decodeTxSigsRS(r *bytes.Reader) error {
 			return fmt.Errorf("failed to read tx sig s: %w", err)
 		}
 		txSig.s, _ = uint256.FromBig(new(big.Int).SetBytes(sigBuffer[:]))
-		txSigs[i] = txSig
+		txSigs = append(txSigs, txSig)
 	}
 	btx.txSigs = txSigs
 	return nil
@@ -266,16 +266,16 @@ func (btx *spanBatchTxs) decodeTxTos(r *bytes.Reader) error {
 }
 
 func (btx *spanBatchTxs) decodeTxDatas(r *bytes.Reader) error {
-	txDatas := make([]hexutil.Bytes, btx.totalBlockTxCount)
-	txTypes := make([]int, btx.totalBlockTxCount)
+	var txDatas []hexutil.Bytes
+	var txTypes []int
 	// Do not need txDataHeader because RLP byte stream already includes length info
 	for i := 0; i < int(btx.totalBlockTxCount); i++ {
 		txData, txType, err := ReadTxData(r)
 		if err != nil {
 			return err
 		}
-		txDatas[i] = txData
-		txTypes[i] = txType
+		txDatas = append(txDatas, txData)
+		txTypes = append(txTypes, txType)
 	}
 	btx.txDatas = txDatas
 	btx.txTypes = txTypes

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -64,6 +64,7 @@ func (btx *spanBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
 	if btx.totalBlockTxCount%8 != 0 {
 		contractCreationBitBufferLen++
 	}
+	// avoid out of memory before allocation
 	if contractCreationBitBufferLen > MaxSpanBatchFieldSize {
 		return ErrTooBigSpanBatchFieldSize
 	}
@@ -184,6 +185,7 @@ func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
 	if btx.totalBlockTxCount%8 != 0 {
 		yParityBitBufferLen++
 	}
+	// avoid out of memory before allocation
 	if yParityBitBufferLen > MaxSpanBatchFieldSize {
 		return ErrTooBigSpanBatchFieldSize
 	}

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -349,8 +349,7 @@ func (btx *spanBatchTxs) decode(r *bytes.Reader) error {
 	if err := btx.decodeTxTos(r); err != nil {
 		return err
 	}
-	err := btx.decodeTxDatas(r)
-	if err != nil {
+	if err := btx.decodeTxDatas(r); err != nil {
 		return err
 	}
 	if err := btx.decodeTxNonces(r); err != nil {

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -123,7 +123,7 @@ func (btx *spanBatchTxs) encodeYParityBits(w io.Writer) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) encodeTxSigs(w io.Writer) error {
+func (btx *spanBatchTxs) encodeTxSigsRS(w io.Writer) error {
 	for _, txSig := range btx.txSigs {
 		rBuf := txSig.r.Bytes32()
 		if _, err := w.Write(rBuf[:]); err != nil {
@@ -203,7 +203,7 @@ func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeTxSigs(r *bytes.Reader) error {
+func (btx *spanBatchTxs) decodeTxSigsRS(r *bytes.Reader) error {
 	txSigs := make([]spanBatchSignature, btx.totalBlockTxCount)
 	var sigBuffer [32]byte
 	for i := 0; i < int(btx.totalBlockTxCount); i++ {
@@ -311,7 +311,7 @@ func (btx *spanBatchTxs) encode(w io.Writer) error {
 	if err := btx.encodeYParityBits(w); err != nil {
 		return err
 	}
-	if err := btx.encodeTxSigs(w); err != nil {
+	if err := btx.encodeTxSigsRS(w); err != nil {
 		return err
 	}
 	if err := btx.encodeTxTos(w); err != nil {
@@ -336,7 +336,7 @@ func (btx *spanBatchTxs) decode(r *bytes.Reader) error {
 	if err := btx.decodeYParityBits(r); err != nil {
 		return err
 	}
-	if err := btx.decodeTxSigs(r); err != nil {
+	if err := btx.decodeTxSigsRS(r); err != nil {
 		return err
 	}
 	if err := btx.decodeTxTos(r); err != nil {

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -36,6 +36,7 @@ type spanBatchSignature struct {
 	s *uint256.Int
 }
 
+// contractCreationBits is bitlist right-padded to a multiple of 8 bits
 func (btx *spanBatchTxs) encodeContractCreationBits(w io.Writer) error {
 	contractCreationBitBufferLen := btx.totalBlockTxCount / 8
 	if btx.totalBlockTxCount%8 != 0 {
@@ -59,6 +60,7 @@ func (btx *spanBatchTxs) encodeContractCreationBits(w io.Writer) error {
 	return nil
 }
 
+// contractCreationBits is bitlist right-padded to a multiple of 8 bits
 func (btx *spanBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
 	contractCreationBitBufferLen := btx.totalBlockTxCount / 8
 	if btx.totalBlockTxCount%8 != 0 {
@@ -103,6 +105,7 @@ func (btx *spanBatchTxs) contractCreationCount() uint64 {
 	return result
 }
 
+// yParityBits is bitlist right-padded to a multiple of 8 bits
 func (btx *spanBatchTxs) encodeYParityBits(w io.Writer) error {
 	yParityBitBufferLen := btx.totalBlockTxCount / 8
 	if btx.totalBlockTxCount%8 != 0 {
@@ -180,6 +183,7 @@ func (btx *spanBatchTxs) encodeTxDatas(w io.Writer) error {
 	return nil
 }
 
+// yParityBits is bitlist right-padded to a multiple of 8 bits
 func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
 	yParityBitBufferLen := btx.totalBlockTxCount / 8
 	if btx.totalBlockTxCount%8 != 0 {

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -65,6 +65,9 @@ func (btx *spanBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
 	if btx.totalBlockTxCount%8 != 0 {
 		contractCreationBitBufferLen++
 	}
+	if contractCreationBitBufferLen > MaxSpanBatchFieldSize {
+		return ErrTooBigSpanBatchFieldSize
+	}
 	contractCreationBitBuffer := make([]byte, contractCreationBitBufferLen)
 	_, err := io.ReadFull(r, contractCreationBitBuffer)
 	if err != nil {
@@ -181,6 +184,9 @@ func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
 	yParityBitBufferLen := btx.totalBlockTxCount / 8
 	if btx.totalBlockTxCount%8 != 0 {
 		yParityBitBufferLen++
+	}
+	if yParityBitBufferLen > MaxSpanBatchFieldSize {
+		return ErrTooBigSpanBatchFieldSize
 	}
 	yParityBitBuffer := make([]byte, yParityBitBufferLen)
 	_, err := io.ReadFull(r, yParityBitBuffer)

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -119,7 +119,7 @@ func TestSpanBatchTxsTxSigs(t *testing.T) {
 	sbt.txSigs = txSigs
 
 	var buf bytes.Buffer
-	err := sbt.encodeTxSigs(&buf)
+	err := sbt.encodeTxSigsRS(&buf)
 	assert.NoError(t, err)
 
 	// txSig field is fixed length: 32 byte + 32 byte = 64 byte
@@ -129,7 +129,7 @@ func TestSpanBatchTxsTxSigs(t *testing.T) {
 	sbt.txSigs = nil
 
 	r := bytes.NewReader(result)
-	err = sbt.decodeTxSigs(r)
+	err = sbt.decodeTxSigsRS(r)
 	assert.NoError(t, err)
 
 	// v field is not set

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBatchTxsContractCreationBits(t *testing.T) {
+func TestSpanBatchTxsContractCreationBits(t *testing.T) {
 	rng := rand.New(rand.NewSource(0x1234567))
 	chainID := big.NewInt(rng.Int63n(1000))
 

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -384,3 +384,21 @@ func TestSpanBatchTxsFullTxNotEnoughTxTos(t *testing.T) {
 	_, err = sbt.fullTxs()
 	assert.EqualError(t, err, "tx to not enough")
 }
+
+func TestSpanBatchTxsMaxContractCreationBitsLength(t *testing.T) {
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = 0xFFFFFFFFFFFFFFFF
+
+	r := bytes.NewReader([]byte{})
+	err := sbt.decodeContractCreationBits(r)
+	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}
+
+func TestSpanBatchTxsMaxYParityBitsLength(t *testing.T) {
+	var sb RawSpanBatch
+	sb.blockCount = 0xFFFFFFFFFFFFFFFF
+
+	r := bytes.NewReader([]byte{})
+	err := sb.decodeOriginBits(r)
+	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -1,0 +1,346 @@
+package derive
+
+import (
+	"bytes"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchTxsContractCreationBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1234567))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	contractCreationBits := rawSpanBatch.txs.contractCreationBits
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeContractCreationBits(&buf)
+	assert.NoError(t, err)
+
+	// contractCreationBit field is fixed length: single bit
+	contractCreationBitBufferLen := totalBlockTxCount / 8
+	if totalBlockTxCount%8 != 0 {
+		contractCreationBitBufferLen++
+	}
+	assert.Equal(t, buf.Len(), int(contractCreationBitBufferLen))
+
+	result := buf.Bytes()
+	sbt.contractCreationBits = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeContractCreationBits(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, contractCreationBits, sbt.contractCreationBits)
+}
+
+func TestSpanBatchTxsContractCreationCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1337))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	contractCreationBits := rawSpanBatch.txs.contractCreationBits
+	contractCreationCount := rawSpanBatch.txs.contractCreationCount()
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeContractCreationBits(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.contractCreationBits = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeContractCreationBits(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, contractCreationCount, sbt.contractCreationCount())
+}
+
+func TestSpanBatchTxsYParityBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x7331))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	yParityBits := rawSpanBatch.txs.yParityBits
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.yParityBits = yParityBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeYParityBits(&buf)
+	assert.NoError(t, err)
+
+	// yParityBit field is fixed length: single bit
+	yParityBitBufferLen := totalBlockTxCount / 8
+	if totalBlockTxCount%8 != 0 {
+		yParityBitBufferLen++
+	}
+	assert.Equal(t, buf.Len(), int(yParityBitBufferLen))
+
+	result := buf.Bytes()
+	sbt.yParityBits = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeYParityBits(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, yParityBits, sbt.yParityBits)
+}
+
+func TestSpanBatchTxsTxSigs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x73311337))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txSigs := rawSpanBatch.txs.txSigs
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.txSigs = txSigs
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxSigs(&buf)
+	assert.NoError(t, err)
+
+	// txSig field is fixed length: 32 byte + 32 byte = 64 byte
+	assert.Equal(t, buf.Len(), 64*int(totalBlockTxCount))
+
+	result := buf.Bytes()
+	sbt.txSigs = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxSigs(r)
+	assert.NoError(t, err)
+
+	// v field is not set
+	for i := 0; i < int(totalBlockTxCount); i++ {
+		assert.Equal(t, txSigs[i].r, sbt.txSigs[i].r)
+		assert.Equal(t, txSigs[i].s, sbt.txSigs[i].s)
+	}
+}
+
+func TestSpanBatchTxsTxNonces(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x123456))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txNonces := rawSpanBatch.txs.txNonces
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.txNonces = txNonces
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxNonces(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txNonces = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxNonces(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, txNonces, sbt.txNonces)
+}
+
+func TestSpanBatchTxsTxGases(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x12345))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txGases := rawSpanBatch.txs.txGases
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.txGases = txGases
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxGases(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txGases = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxGases(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, txGases, sbt.txGases)
+}
+
+func TestSpanBatchTxsTxTos(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x54321))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txTos := rawSpanBatch.txs.txTos
+	contractCreationBits := rawSpanBatch.txs.contractCreationBits
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.txTos = txTos
+	// creation bits and block tx count must be se to decode tos
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxTos(&buf)
+	assert.NoError(t, err)
+
+	// to field is fixed length: 20 bytes
+	assert.Equal(t, buf.Len(), 20*len(txTos))
+
+	result := buf.Bytes()
+	sbt.txTos = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxTos(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, txTos, sbt.txTos)
+}
+
+func TestSpanBatchTxsTxDatas(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1234))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txDatas := rawSpanBatch.txs.txDatas
+	txTypes := rawSpanBatch.txs.txTypes
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	sbt.txDatas = txDatas
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxDatas(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txDatas = nil
+	sbt.txTypes = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxDatas(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, txDatas, sbt.txDatas)
+	assert.Equal(t, txTypes, sbt.txTypes)
+}
+
+func TestSpanBatchTxsRecoverV(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x123))
+
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+	totalblockTxCount := rng.Intn(100)
+
+	var spanBatchTxs spanBatchTxs
+	var txTypes []int
+	var txSigs []spanBatchSignature
+	var originalVs []uint64
+	yParityBits := new(big.Int)
+	for idx := 0; idx < totalblockTxCount; idx++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		txTypes = append(txTypes, int(tx.Type()))
+		var txSig spanBatchSignature
+		v, r, s := tx.RawSignatureValues()
+		// Do not fill in txSig.V
+		txSig.r, _ = uint256.FromBig(r)
+		txSig.s, _ = uint256.FromBig(s)
+		txSigs = append(txSigs, txSig)
+		originalVs = append(originalVs, v.Uint64())
+		yParityBit := convertVToYParity(v.Uint64(), int(tx.Type()))
+		yParityBits.SetBit(yParityBits, idx, yParityBit)
+	}
+
+	spanBatchTxs.chainID = chainID
+	spanBatchTxs.yParityBits = yParityBits
+	spanBatchTxs.txSigs = txSigs
+	spanBatchTxs.txTypes = txTypes
+	// recover txSig.v
+	spanBatchTxs.recoverV()
+
+	var recoveredVs []uint64
+	for _, txSig := range spanBatchTxs.txSigs {
+		recoveredVs = append(recoveredVs, txSig.v)
+	}
+
+	assert.Equal(t, originalVs, recoveredVs, "recovered v mismatch")
+}
+
+func TestSpanBatchTxsRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x73311337))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	for i := 0; i < 4; i++ {
+		rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+		sbt := rawSpanBatch.txs
+		totalBlockTxCount := sbt.totalBlockTxCount
+
+		var buf bytes.Buffer
+		err := sbt.encode(&buf)
+		assert.NoError(t, err)
+
+		result := buf.Bytes()
+		r := bytes.NewReader(result)
+
+		var sbt2 spanBatchTxs
+		sbt2.chainID = chainID
+		sbt2.totalBlockTxCount = totalBlockTxCount
+		err = sbt2.decode(r)
+		assert.NoError(t, err)
+		sbt2.recoverV()
+
+		assert.Equal(t, sbt, &sbt2)
+	}
+}
+
+func TestSpanBatchTxsRoundTripFullTxs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x13377331))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	for i := 0; i < 4; i++ {
+		totalblockTxCounts := uint64(1 + rng.Int()&0xFF)
+		var txs [][]byte
+		for i := 0; i < int(totalblockTxCounts); i++ {
+			tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+			rawTx, err := tx.MarshalBinary()
+			assert.NoError(t, err)
+			txs = append(txs, rawTx)
+		}
+		sbt, err := newSpanBatchTxs(txs, chainID)
+		assert.NoError(t, err)
+
+		txs2, err := sbt.fullTxs()
+		assert.NoError(t, err)
+
+		assert.Equal(t, txs, txs2)
+	}
+}

--- a/op-node/rollup/derive/spna_batch_txs_test.go
+++ b/op-node/rollup/derive/spna_batch_txs_test.go
@@ -1,1 +1,0 @@
-package derive

--- a/op-node/rollup/derive/spna_batch_txs_test.go
+++ b/op-node/rollup/derive/spna_batch_txs_test.go
@@ -1,0 +1,1 @@
+package derive


### PR DESCRIPTION
## Tests

Added tests for data structure(types). Every test is unit test. The tests cover `batch.go`, `span_batch.go`, `span_batch_tx.go`, `span_batch_txs.go`.

Most of tests at `batch_test.go` is refactored or removed because the code structure changed drastically, compared to the point that those tests were added.

Added and fixed helper methods: `RandomSingularBatch`, `RandomValidConsecutiveSingularBatches`, `mockL1Origin`.

## Styles & Refactoring

Added comments. Refactoring:

1. Make sure avoiding oom errors while deserialization. Throw `ErrTooBigSpanBatchFieldSize` when assumed field size is greater than 10 MB.
2. Rename variable `chainId` to `chainID`.
3. Remove implicit field `chainID` of `spanBatchTxs`. This change caused function signature of `RecoverV`, `fullTx` method to be updated.
4. Rename `decodeTxSigs/encodeTxSigs` to `decodeTxSigsRS/encodeTxSigsRS`. It is because the method actually only decodes `R` and `S`, not `V`.
5. Error handle `NewSpanBatch` method when input list length is empty.
6. Refactor encoding/decoding method for unit testing.
7. Make `RandomSingularBatch` to produce singular batch which contains equal chainID for its transactions.
