### PR TITLE
Allow overlapping span batch

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -154,18 +154,10 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 			return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 		}
 		// If next batch is SpanBatch, convert it to SingularBatches.
-		singularBatches, err := spanBatch.GetSingularBatches(bq.l1Blocks)
+		singularBatches, err := spanBatch.GetSingularBatches(bq.l1Blocks, safeL2Head)
 		if err != nil {
 			return nil, NewCriticalError(err)
 		}
-		// Pop first one and return
-		i := 0
-		for ; i < len(singularBatches); i++ {
-			if singularBatches[i].Timestamp > safeL2Head.Time {
-				break
-			}
-		}
-		bq.nextSpan = singularBatches[i:]
 		nextBatch := bq.popNextBatch(safeL2Head)
 		return nextBatch, nil
 	default:

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -158,6 +158,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 		if err != nil {
 			return nil, NewCriticalError(err)
 		}
+		bq.nextSpan = singularBatches
 		nextBatch := bq.popNextBatch(safeL2Head)
 		return nextBatch, nil
 	default:

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -32,6 +32,11 @@ type NextBatchProvider interface {
 	NextBatch(ctx context.Context) (Batch, error)
 }
 
+type SafeBlockFetcher interface {
+	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
+	PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayload, error)
+}
+
 // BatchQueue contains a set of batches for every L1 block.
 // L1 blocks are contiguous and this does not support reorgs.
 type BatchQueue struct {
@@ -47,14 +52,17 @@ type BatchQueue struct {
 
 	// nextSpan is cached SingularBatches derived from SpanBatch
 	nextSpan []*SingularBatch
+
+	l2 SafeBlockFetcher
 }
 
 // NewBatchQueue creates a BatchQueue, which should be Reset(origin) before use.
-func NewBatchQueue(log log.Logger, cfg *rollup.Config, prev NextBatchProvider) *BatchQueue {
+func NewBatchQueue(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher) *BatchQueue {
 	return &BatchQueue{
 		log:    log,
 		config: cfg,
 		prev:   prev,
+		l2:     l2,
 	}
 }
 

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -33,8 +33,8 @@ type NextBatchProvider interface {
 }
 
 type SafeBlockFetcher interface {
-	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
-	PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayload, error)
+	L2BlockRefByNumber(context.Context, uint64) (eth.L2BlockRef, error)
+	PayloadByNumber(context.Context, uint64) (*eth.ExecutionPayload, error)
 }
 
 // BatchQueue contains a set of batches for every L1 block.

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -158,7 +158,7 @@ func BatchQueueNewOrigin(t *testing.T, batchType int) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 	require.Equal(t, []eth.L1BlockRef{l1[0]}, bq.l1Blocks)
 
@@ -247,7 +247,7 @@ func BatchQueueEager(t *testing.T, batchType int) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 	// Advance the origin
 	input.origin = l1[1]
@@ -325,7 +325,7 @@ func BatchQueueInvalidInternalAdvance(t *testing.T, batchType int) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 
 	// Load continuous batches for epoch 0
@@ -440,7 +440,7 @@ func BatchQueueMissing(t *testing.T, batchType int) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 
 	for i := 0; i < len(expectedOutputBatches); i++ {
@@ -567,7 +567,7 @@ func BatchQueueAdvancedEpoch(t *testing.T, batchType int) {
 		origin:  l1[inputOriginNumber],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
 
 	for i := 0; i < len(expectedOutputBatches); i++ {
@@ -660,7 +660,7 @@ func BatchQueueShuffle(t *testing.T, batchType int) {
 		origin:  l1[inputOriginNumber],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
 
 	for i := 0; i < len(expectedOutputBatches); i++ {

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -85,9 +85,9 @@ func getSpanBatchTime(batchType int) *uint64 {
 	return &maxTs
 }
 
-func l1InfoDepositTx(t *testing.T, l1BLockNum uint64) hexutil.Bytes {
+func l1InfoDepositTx(t *testing.T, l1BlockNum uint64) hexutil.Bytes {
 	l1Info := L1BlockInfo{
-		Number:  l1BLockNum,
+		Number:  l1BlockNum,
 		BaseFee: big.NewInt(0),
 	}
 	infoData, err := l1Info.MarshalBinary()

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -85,6 +85,43 @@ func getSpanBatchTime(batchType int) *uint64 {
 	return &maxTs
 }
 
+func l1InfoDepositTx(t *testing.T, l1BLockNum uint64) hexutil.Bytes {
+	l1Info := L1BlockInfo{
+		Number:  l1BLockNum,
+		BaseFee: big.NewInt(0),
+	}
+	infoData, err := l1Info.MarshalBinary()
+	require.NoError(t, err)
+	depositTx := &types.DepositTx{
+		Data: infoData,
+	}
+	txData, err := types.NewTx(depositTx).MarshalBinary()
+	require.NoError(t, err)
+	return txData
+}
+
+func singularBatchToPayload(t *testing.T, batch *SingularBatch, blockNumber uint64) eth.ExecutionPayload {
+	txs := []hexutil.Bytes{l1InfoDepositTx(t, uint64(batch.EpochNum))}
+	txs = append(txs, batch.Transactions...)
+	return eth.ExecutionPayload{
+		BlockHash:    mockHash(batch.Timestamp, 2),
+		ParentHash:   batch.ParentHash,
+		BlockNumber:  hexutil.Uint64(blockNumber),
+		Timestamp:    hexutil.Uint64(batch.Timestamp),
+		Transactions: txs,
+	}
+}
+
+func singularBatchToBlockRef(t *testing.T, batch *SingularBatch, blockNumber uint64) eth.L2BlockRef {
+	return eth.L2BlockRef{
+		Hash:       mockHash(batch.Timestamp, 2),
+		Number:     blockNumber,
+		ParentHash: batch.ParentHash,
+		Time:       batch.Timestamp,
+		L1Origin:   eth.BlockID{batch.EpochHash, uint64(batch.EpochNum)},
+	}
+}
+
 func L1Chain(l1Times []uint64) []eth.L1BlockRef {
 	var out []eth.L1BlockRef
 	var parentHash common.Hash
@@ -549,7 +586,7 @@ func BatchQueueAdvancedEpoch(t *testing.T, batchType int) {
 	// batches will be returned by fakeBatchQueueInput
 	var inputBatches []Batch
 	if batchType == SpanBatchType {
-		spanBlockCounts := []int{1, 2, 3, 3}
+		spanBlockCounts := []int{2, 2, 2, 3}
 		inputErrors = []error{nil, nil, nil, nil, io.EOF}
 		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
 		inputBatches = append(inputBatches, nil)
@@ -583,7 +620,6 @@ func BatchQueueAdvancedEpoch(t *testing.T, batchType int) {
 			require.Nil(t, expectedOutput)
 		} else {
 			require.Equal(t, expectedOutput, b)
-			require.Equal(t, bq.origin, input.origin)
 			require.Equal(t, bq.l1Blocks[0].Number, uint64(b.EpochNum))
 			safeHead.Number += 1
 			safeHead.Time += cfg.BlockTime
@@ -637,7 +673,7 @@ func BatchQueueShuffle(t *testing.T, batchType int) {
 	// batches will be returned by fakeBatchQueueInput
 	var inputBatches []Batch
 	if batchType == SpanBatchType {
-		spanBlockCounts := []int{1, 2, 3, 3}
+		spanBlockCounts := []int{2, 2, 2, 3}
 		inputErrors = []error{nil, nil, nil, nil, io.EOF}
 		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
 	} else {
@@ -684,7 +720,198 @@ func BatchQueueShuffle(t *testing.T, batchType int) {
 			require.Nil(t, expectedOutput)
 		} else {
 			require.Equal(t, expectedOutput, b)
-			require.Equal(t, bq.origin, input.origin)
+			require.Equal(t, bq.l1Blocks[0].Number, uint64(b.EpochNum))
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+}
+
+func TestBatchQueueOverlappingSpanBatch(t *testing.T) {
+	log := testlog.Logger(t, log.LvlCrit)
+	l1 := L1Chain([]uint64{10, 20, 30})
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(10, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           10,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: genesisTimestamp,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		SpanBatchTime:     getSpanBatchTime(SpanBatchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		b(cfg.L2ChainID, 12, l1[0]),
+		b(cfg.L2ChainID, 14, l1[0]),
+		b(cfg.L2ChainID, 16, l1[0]),
+		b(cfg.L2ChainID, 18, l1[0]),
+		b(cfg.L2ChainID, 20, l1[0]),
+		b(cfg.L2ChainID, 22, l1[0]),
+		nil,
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := []error{nil, nil, nil, nil, io.EOF}
+
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	batchSize := 3
+	for i := 0; i < len(expectedOutputBatches)-batchSize; i++ {
+		inputBatches = append(inputBatches, NewSpanBatch(expectedOutputBatches[i:i+batchSize]))
+	}
+	inputBatches = append(inputBatches, nil)
+
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[0],
+	}
+
+	l2Client := testutils.MockL2Client{}
+	var nilErr error
+	for i, batch := range expectedOutputBatches {
+		if batch != nil {
+			blockRef := singularBatchToBlockRef(t, batch, uint64(i+1))
+			payload := singularBatchToPayload(t, batch, uint64(i+1))
+			l2Client.Mock.On("L2BlockRefByNumber", uint64(i+1)).Times(9999).Return(blockRef, &nilErr)
+			l2Client.Mock.On("PayloadByNumber", uint64(i+1)).Times(9999).Return(&payload, &nilErr)
+		}
+	}
+
+	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
+	// Advance the origin
+	input.origin = l1[1]
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		b, e := bq.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutputBatches[i])
+		} else {
+			require.Equal(t, expectedOutputBatches[i], b)
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+}
+
+func TestBatchQueueComplex(t *testing.T) {
+	log := testlog.Logger(t, log.LvlCrit)
+	l1 := L1Chain([]uint64{0, 6, 12, 18, 24}) // L1 block time: 6s
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(4, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           4,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: genesisTimestamp,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		SpanBatchTime:     getSpanBatchTime(SpanBatchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		// 3 L2 blocks per L1 block
+		b(cfg.L2ChainID, 6, l1[1]),
+		b(cfg.L2ChainID, 8, l1[1]),
+		b(cfg.L2ChainID, 10, l1[1]),
+		b(cfg.L2ChainID, 12, l1[2]),
+		b(cfg.L2ChainID, 14, l1[2]),
+		b(cfg.L2ChainID, 16, l1[2]),
+		b(cfg.L2ChainID, 18, l1[3]),
+		b(cfg.L2ChainID, 20, l1[3]),
+		b(cfg.L2ChainID, 22, l1[3]),
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// batches will be returned by fakeBatchQueueInput
+	inputBatches := []Batch{
+		NewSpanBatch(expectedOutputBatches[0:2]), // 6, 8
+		expectedOutputBatches[2],                 // 10
+		NewSpanBatch(expectedOutputBatches[1:4]), // 8, 10, 12
+		expectedOutputBatches[4],                 // 14
+		NewSpanBatch(expectedOutputBatches[4:6]), // 14, 16
+		NewSpanBatch(expectedOutputBatches[6:9]), // 18, 20, 22
+	}
+
+	// Shuffle the order of input batches
+	rand.Shuffle(len(inputBatches), func(i, j int) {
+		inputBatches[i], inputBatches[j] = inputBatches[j], inputBatches[i]
+	})
+
+	inputBatches = append(inputBatches, nil)
+
+	// ChannelInReader origin number
+	inputOriginNumber := 2
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[inputOriginNumber],
+	}
+
+	l2Client := testutils.MockL2Client{}
+	var nilErr error
+	for i, batch := range expectedOutputBatches {
+		if batch != nil {
+			blockRef := singularBatchToBlockRef(t, batch, uint64(i+1))
+			payload := singularBatchToPayload(t, batch, uint64(i+1))
+			l2Client.Mock.On("L2BlockRefByNumber", uint64(i+1)).Times(9999).Return(blockRef, &nilErr)
+			l2Client.Mock.On("PayloadByNumber", uint64(i+1)).Times(9999).Return(&payload, &nilErr)
+		}
+	}
+
+	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		expectedOutput := expectedOutputBatches[i]
+		if expectedOutput != nil && uint64(expectedOutput.EpochNum) == l1[inputOriginNumber].Number {
+			// Advance ChannelInReader origin if needed
+			inputOriginNumber += 1
+			input.origin = l1[inputOriginNumber]
+		}
+		var b *SingularBatch
+		var e error
+		for j := 0; j < len(expectedOutputBatches); j++ {
+			// Multiple NextBatch() executions may be required because the order of input is shuffled
+			b, e = bq.NextBatch(context.Background(), safeHead)
+			if !errors.Is(e, NotEnoughData) {
+				break
+			}
+		}
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutput)
+		} else {
+			require.Equal(t, expectedOutput, b)
 			require.Equal(t, bq.l1Blocks[0].Number, uint64(b.EpochNum))
 			safeHead.Number += 1
 			safeHead.Time += cfg.BlockTime

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -250,6 +250,11 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 		return BatchUndecided
 	}
 
+	if startEpochNum < parentBlock.L1Origin.Number {
+		log.Warn("dropped batch, epoch is too old", "minimum", parentBlock.ID())
+		return BatchDrop
+	}
+
 	originIdx := 0
 	originAdvanced := false
 	if startEpochNum == parentBlock.L1Origin.Number+1 {

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -167,7 +167,7 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 	return BatchAccept
 }
 
-// checkSingularBatch implements SpanBatch validation rule.
+// checkSpanBatch implements SpanBatch validation rule.
 func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
 	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher) BatchValidity {
 	// add details to the log
@@ -336,7 +336,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 			}
 			safeBlockTxs := safeBlockPayload.Transactions
 			batchTxs := batch.GetBlockTransactions(int(i))
-			// execution payload has L1 info deposit TX, but batch does not.
+			// execution payload has deposit TXs, but batch does not.
 			depositCount := 0
 			for _, tx := range safeBlockTxs {
 				if tx[0] == types.DepositTxType {

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -35,7 +35,7 @@ type Engine interface {
 	PayloadByNumber(context.Context, uint64) (*eth.ExecutionPayload, error)
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 	L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error)
-	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)s
+	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	SystemConfigL2Fetcher
 }
 

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -35,6 +35,7 @@ type Engine interface {
 	PayloadByNumber(context.Context, uint64) (*eth.ExecutionPayload, error)
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 	L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error)
+	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)s
 	SystemConfigL2Fetcher
 }
 

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -90,7 +90,7 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	frameQueue := NewFrameQueue(log, l1Src)
 	bank := NewChannelBank(log, cfg, frameQueue, l1Fetcher, metrics)
 	chInReader := NewChannelInReader(log, cfg, bank, metrics)
-	batchQueue := NewBatchQueue(log, cfg, chInReader)
+	batchQueue := NewBatchQueue(log, cfg, chInReader, engine)
 	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, engine)
 	attributesQueue := NewAttributesQueue(log, cfg, attrBuilder, batchQueue)
 

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -320,8 +320,8 @@ func (b *SpanBatch) CheckParentHash(hash common.Hash) bool {
 }
 
 // GetBlockOriginNum returns the epoch number(L1 origin block number) of the block at the given index in the span.
-func (b *SpanBatch) GetBlockOriginNum(i int) rollup.Epoch {
-	return b.batches[i].EpochNum
+func (b *SpanBatch) GetBlockOriginNum(i int) uint64 {
+	return uint64(b.batches[i].EpochNum)
 }
 
 // GetBlockTimestamp returns the timestamp of the block at the given index in the span.

--- a/op-node/testutils/mock_l2.go
+++ b/op-node/testutils/mock_l2.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"context"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -13,7 +12,8 @@ type MockL2Client struct {
 }
 
 func (c *MockL2Client) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
-	return c.Mock.MethodCalled("L2BlockRefByLabel", label).Get(0).(eth.L2BlockRef), nil
+	out := c.Mock.MethodCalled("L2BlockRefByLabel", label)
+	return out[0].(eth.L2BlockRef), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectL2BlockRefByLabel(label eth.BlockLabel, ref eth.L2BlockRef, err error) {
@@ -21,7 +21,8 @@ func (m *MockL2Client) ExpectL2BlockRefByLabel(label eth.BlockLabel, ref eth.L2B
 }
 
 func (c *MockL2Client) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
-	return c.Mock.MethodCalled("L2BlockRefByNumber", num).Get(0).(eth.L2BlockRef), nil
+	out := c.Mock.MethodCalled("L2BlockRefByNumber", num)
+	return out[0].(eth.L2BlockRef), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectL2BlockRefByNumber(num uint64, ref eth.L2BlockRef, err error) {
@@ -29,7 +30,8 @@ func (m *MockL2Client) ExpectL2BlockRefByNumber(num uint64, ref eth.L2BlockRef, 
 }
 
 func (c *MockL2Client) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error) {
-	return c.Mock.MethodCalled("L2BlockRefByHash", hash).Get(0).(eth.L2BlockRef), nil
+	out := c.Mock.MethodCalled("L2BlockRefByHash", hash)
+	return out[0].(eth.L2BlockRef), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectL2BlockRefByHash(hash common.Hash, ref eth.L2BlockRef, err error) {
@@ -37,7 +39,8 @@ func (m *MockL2Client) ExpectL2BlockRefByHash(hash common.Hash, ref eth.L2BlockR
 }
 
 func (m *MockL2Client) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
-	return m.Mock.MethodCalled("SystemConfigByL2Hash", hash).Get(0).(eth.SystemConfig), nil
+	out := m.Mock.MethodCalled("SystemConfigByL2Hash", hash)
+	return out[0].(eth.SystemConfig), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectSystemConfigByL2Hash(hash common.Hash, cfg eth.SystemConfig, err error) {
@@ -45,7 +48,8 @@ func (m *MockL2Client) ExpectSystemConfigByL2Hash(hash common.Hash, cfg eth.Syst
 }
 
 func (m *MockL2Client) OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
-	return m.Mock.MethodCalled("OutputV0AtBlock", blockHash).Get(0).(*eth.OutputV0), nil
+	out := m.Mock.MethodCalled("OutputV0AtBlock", blockHash)
+	return out[0].(*eth.OutputV0), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectOutputV0AtBlock(blockHash common.Hash, output *eth.OutputV0, err error) {

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -105,6 +105,18 @@ func (o *OracleEngine) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash)
 	return derive.L2BlockToBlockRef(block, &o.rollupCfg.Genesis)
 }
 
+func (o *OracleEngine) L2BlockRefByNumber(ctx context.Context, n uint64) (eth.L2BlockRef, error) {
+	hash := o.backend.GetCanonicalHash(n)
+	if hash == (common.Hash{}) {
+		return eth.L2BlockRef{}, ErrNotFound
+	}
+	block := o.backend.GetBlockByHash(hash)
+	if block == nil {
+		return eth.L2BlockRef{}, ErrNotFound
+	}
+	return derive.L2BlockToBlockRef(block, &o.rollupCfg.Genesis)
+}
+
 func (o *OracleEngine) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
 	payload, err := o.PayloadByHash(ctx, hash)
 	if err != nil {

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -282,6 +282,8 @@ Span-batch rules, in validation order:
         is past `inclusion_block_number` because of the following invariant.
       - Invariant: the epoch-num in the batch is always less than the inclusion block number,
         if and only if the L1 epoch hash is correct.
+    - `start_epoch_num < prev_l2_block.l1_origin.number` -> `drop`:
+      epoch number cannot be older than the origin of parent block
 - Max Sequencer time-drift checks:
   - Note: The max time-drift is enforced for the *batch as a whole*, to keep the possible output variants small.
   - Variables:

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -263,16 +263,6 @@ Span-batch rules, in validation order:
 - If there's no `prev_l2_block` in the current safe chain -> `drop`: i.e. misaligned timestamp
 - `batch.parent_check != prev_l2_block.hash[:20]` -> `drop`:
   i.e. the checked part of the parent hash must be equal to the corresponding safe block.
-- Overlapped blocks checks:
-  - Note: If the span batch overlaps the current L2 safe chain, we must validate all overlapped blocks.
-  - Variables:
-    - `block_input`: an L2 block derived from the span-batch.
-    - `safe_block`: an L2 block from the current L2 safe chain, at same timestamp as `block_input`
-  - Rules:
-    - For each `block_input`, whose timestamp is less than `next_timestamp`:
-      - If there's no `safe_block` for the `block_input` -> `drop`: i.e. misaligned timestamp
-      - `block_input.l1_origin.number != safe_block.l1_origin.number` -> `drop`
-      - `block_input.transactions != safe_block.transactions` -> `drop`
 - Sequencing-window checks:
   - Note: The sequencing window is enforced for the *batch as a whole*:
     if the batch was partially invalid instead, it would drop the oldest L2 blocks,
@@ -319,6 +309,17 @@ Span-batch rules, in validation order:
     that is invalid or derived by other means exclusively:
     - any transaction that is empty (zero length `tx_data`)
     - any [deposited transactions][g-deposit-tx-type] (identified by the transaction type prefix byte in `tx_data`)
+- Overlapped blocks checks:
+  - Note: If the span batch overlaps the current L2 safe chain, we must validate all overlapped blocks.
+  - Variables:
+    - `block_input`: an L2 block derived from the span-batch.
+    - `safe_block`: an L2 block from the current L2 safe chain, at same timestamp as `block_input`
+  - Rules:
+    - For each `block_input`, whose timestamp is less than `next_timestamp`:
+      - If there's no `safe_block` for the `block_input` -> `drop`: i.e. misaligned timestamp
+      - `block_input.l1_origin.number != safe_block.l1_origin.number` -> `drop`
+      - `block_input.transactions != safe_block.transactions` -> `drop`
+        - compare excluding deposit transactions
 
 Once validated, the batch-queue then emits a block-input for each of the blocks included in the span-batch.
 The next derivation stage is thus only aware of individual block inputs, similar to the previous V0 batch,

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -253,15 +253,15 @@ Rules are enforced with the [contextual definitions](./derivation.md#batch-queue
 
 Definitions:
 - `batch` as defined in the [Span batch format section][span-batch-format].
-- `parent_safe_block` is the L2 block from the current safe chain,
+- `prev_l2_block` is the L2 block from the current safe chain,
   whose timestamp is at `span_start.timestamp - l2_block_time`
 
 Span-batch rules, in validation order:
 
 - `span_start.timestamp > next_timestamp` -> `future`: i.e. the batch must be ready to process.
 - `span_end.timestamp < next_timestamp` -> `drop`: i.e. the batch must have at least one new block.
-- If there's no `parent_safe_block` in the current safe chain -> `drop`: i.e. misaligned timestamp
-- `batch.parent_check != parent_safe_block.hash[:20]` -> `drop`:
+- If there's no `prev_l2_block` in the current safe chain -> `drop`: i.e. misaligned timestamp
+- `batch.parent_check != prev_l2_block.hash[:20]` -> `drop`:
   i.e. the checked part of the parent hash must be equal to the corresponding safe block.
 - Overlapped blocks checks:
   - Note: If the span batch overlaps the current L2 safe chain, we must validate all overlapped blocks.
@@ -284,7 +284,7 @@ Span-batch rules, in validation order:
   - Rules:
     - `start_epoch_num + sequence_window_size < inclusion_block_number` -> `drop`:
       i.e. the batch must be included timely.
-    - `start_epoch_num > parent_safe_block.l1_origin.number + 1` -> `drop`:
+    - `start_epoch_num > prev_l2_block.l1_origin.number + 1` -> `drop`:
       i.e. the L1 origin cannot change by more than one L1 block per L2 block.
     - If `batch.l1_origin_check` does not match the canonical L1 chain at `end_epoch_num` -> `drop`:
       verify the batch is intended for this L1 chain.

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -254,7 +254,7 @@ Rules are enforced with the [contextual definitions](./derivation.md#batch-queue
 Definitions:
 - `batch` as defined in the [Span batch format section][span-batch-format].
 - `parent_safe_block` is the L2 block from the current safe chain,
-  whose timestamp is at `span_start.timestamp - block_time`
+  whose timestamp is at `span_start.timestamp - l2_block_time`
 
 Span-batch rules, in validation order:
 
@@ -271,9 +271,8 @@ Span-batch rules, in validation order:
   - Rules:
     - For each `block_input`, whose timestamp is less than `next_timestamp`:
       - If there's no `safe_block` for the `block_input` -> `drop`: i.e. misaligned timestamp
-      - `block_input.origin.number != safe_block.origin.number` -> `drop`
+      - `block_input.l1_origin.number != safe_block.l1_origin.number` -> `drop`
       - `block_input.transactions != safe_block.transactions` -> `drop`
-        - `transactions` is a list of EIP-2718 transactions
 - Sequencing-window checks:
   - Note: The sequencing window is enforced for the *batch as a whole*:
     if the batch was partially invalid instead, it would drop the oldest L2 blocks,
@@ -301,7 +300,7 @@ Span-batch rules, in validation order:
     - `next_epoch`: `block_input.origin`'s next L1 block.
       It may reach to the next origin outside the L1 origins of the span.
   - Rules:
-    - For each `block_input`, whose timestamp is greater than `safe_head.timestamp`:
+    - For each `block_input` whose timestamp is greater than `safe_head.timestamp`:
       - `block_input.timestamp < block_input.origin.time` -> `drop`: enforce the min L2 timestamp rule.
       - `block_input.timestamp > block_input.origin.time + max_sequencer_drift`: enforce the L2 timestamp drift rule,
         but with exceptions to preserve above min L2 timestamp invariant:

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -63,6 +63,8 @@ Span-batches address these inefficiencies, with a new batch format version.
 
 ## Span batch format
 
+[span-batch-format]: #span-batch-format
+
 Note that span-batches, unlike previous singular batches,
 encode *a range of consecutive* L2 blocks at the same time.
 
@@ -220,7 +222,7 @@ The assumption makes upper inequality to hold. Therefore, we decided to manage `
   - If the last block references canonical L1 chain as its origin,
     we can ensure the all other blocks' origins are consistent with the canonical L1 chain.
 - Parent hash
-  - In V0 Batch spec, we need batch's parent hash to validate if batch's parent is consistent with current L2 safe head.
+  - In V0 Batch spec, we need batch's parent hash to validate if batch's parent is consistent with current L2 chain.
   - But in the case of Span Batch, because it contains consecutive L2 blocks in the span,
     we do not need to validate all blocks' parent hash except the first block.
 - Transactions
@@ -247,14 +249,31 @@ Span-batches share the same queue with v0 batches: batches are processed in L1 i
 A set of modified validation rules apply to the span-batches.
 
 Rules are enforced with the [contextual definitions](./derivation.md#batch-queue) as v0-batch validation:
-`batch`, `epoch`, `inclusion_block_number`, `next_timestamp`, `next_epoch`, `batch_origin`
+`epoch`, `inclusion_block_number`, `next_timestamp`
+
+Definitions:
+- `batch` as defined in the [Span batch format section][span-batch-format].
+- `parent_safe_block` is the L2 block from the current safe chain,
+  whose timestamp is at `span_start.timestamp - block_time`
 
 Span-batch rules, in validation order:
 
-- `batch.start_timestamp > next_timestamp` -> `future`: i.e. the batch must be ready to process.
-- `batch.start_timestamp < next_timestamp` -> `drop`: i.e. the batch must not be too old.
-- `batch.parent_check != safe_l2_head.hash[:20]` -> `drop`: i.e. the checked part of the parent hash must be equal
-  to the L2 safe head block hash.
+- `span_start.timestamp > next_timestamp` -> `future`: i.e. the batch must be ready to process.
+- `span_end.timestamp < next_timestamp` -> `drop`: i.e. the batch must have at least one new block.
+- If there's no `parent_safe_block` in the current safe chain -> `drop`: i.e. misaligned timestamp
+- `batch.parent_check != parent_safe_block.hash[:20]` -> `drop`:
+  i.e. the checked part of the parent hash must be equal to the corresponding safe block.
+- Overlapped blocks checks:
+  - Note: If the span batch overlaps the current L2 safe chain, we must validate all overlapped blocks.
+  - Variables:
+    - `block_input`: an L2 block derived from the span-batch.
+    - `safe_block`: an L2 block from the current L2 safe chain, at same timestamp as `block_input`
+  - Rules:
+    - For each `block_input`, whose timestamp is less than `next_timestamp`:
+      - If there's no `safe_block` for the `block_input` -> `drop`: i.e. misaligned timestamp
+      - `block_input.origin.number != safe_block.origin.number` -> `drop`
+      - `block_input.transactions != safe_block.transactions` -> `drop`
+        - `transactions` is a list of EIP-2718 transactions
 - Sequencing-window checks:
   - Note: The sequencing window is enforced for the *batch as a whole*:
     if the batch was partially invalid instead, it would drop the oldest L2 blocks,
@@ -266,7 +285,7 @@ Span-batch rules, in validation order:
   - Rules:
     - `start_epoch_num + sequence_window_size < inclusion_block_number` -> `drop`:
       i.e. the batch must be included timely.
-    - `start_epoch_num > epoch.number + 1` -> `drop`:
+    - `start_epoch_num > parent_safe_block.l1_origin.number + 1` -> `drop`:
       i.e. the L1 origin cannot change by more than one L1 block per L2 block.
     - If `batch.l1_origin_check` does not match the canonical L1 chain at `end_epoch_num` -> `drop`:
       verify the batch is intended for this L1 chain.
@@ -274,9 +293,6 @@ Span-batch rules, in validation order:
         is past `inclusion_block_number` because of the following invariant.
       - Invariant: the epoch-num in the batch is always less than the inclusion block number,
         if and only if the L1 epoch hash is correct.
-    - `start_epoch_num < epoch.number` -> `drop`: must have been duplicate batch,
-      we may be past this L1 block in the safe L2 chain. If a span-batch overlaps with older information,
-      it is dropped, since partially valid span-batches are not accepted.
 - Max Sequencer time-drift checks:
   - Note: The max time-drift is enforced for the *batch as a whole*, to keep the possible output variants small.
   - Variables:
@@ -285,7 +301,7 @@ Span-batch rules, in validation order:
     - `next_epoch`: `block_input.origin`'s next L1 block.
       It may reach to the next origin outside the L1 origins of the span.
   - Rules:
-    - For each `block_input` that can be read from the span-batch:
+    - For each `block_input`, whose timestamp is greater than `safe_head.timestamp`:
       - `block_input.timestamp < block_input.origin.time` -> `drop`: enforce the min L2 timestamp rule.
       - `block_input.timestamp > block_input.origin.time + max_sequencer_drift`: enforce the L2 timestamp drift rule,
         but with exceptions to preserve above min L2 timestamp invariant:


### PR DESCRIPTION
## Context
- Current span batch spec does not allow span batches that overlaps current safe chain.
- So the op-node cannot proceed derivation if the pipeline is reset to the middle of span batch.
- It's very hard to guarantee that the op-node will always reset the safe head to the boundary of the span batch.
- Therefore we need to allow overlapping span batches.

## Changes
- Specs
  - Updated span batch validation rules to allow overlapping batches
- op-e2e test
  - Added a test case to simulate reorg scenario that should be failed on the current specs. 
    - After the L1 reorg, derivation pipeline is reset to the middle of span batch.
  - So this test case fails for now, with `OP_E2E_USE_SPAN_BATCH=true` env.