### PR TITLE
op-node: Span Batch Hardfork Configuration

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -109,6 +109,9 @@ type DeployConfig struct {
 	// L2GenesisRegolithTimeOffset is the number of seconds after genesis block that Regolith hard fork activates.
 	// Set it to 0 to activate at genesis. Nil to disable regolith.
 	L2GenesisRegolithTimeOffset *hexutil.Uint64 `json:"l2GenesisRegolithTimeOffset,omitempty"`
+	// L2GenesisSpanBatchTimeOffset is the number of seconds after genesis block that Span Batch hard fork activates.
+	// Set it to 0 to activate at genesis. Nil to disable SpanBatch.
+	L2GenesisSpanBatchTimeOffset *hexutil.Uint64 `json:"l2GenesisSpanBatchTimeOffset,omitempty"`
 	// L2GenesisBlockExtraData is configurable extradata. Will default to []byte("BEDROCK") if left unspecified.
 	L2GenesisBlockExtraData []byte `json:"l2GenesisBlockExtraData"`
 	// ProxyAdminOwner represents the owner of the ProxyAdmin predeploy on L2.
@@ -441,6 +444,17 @@ func (d *DeployConfig) RegolithTime(genesisTime uint64) *uint64 {
 	return &v
 }
 
+func (d *DeployConfig) SpanBatchTime(genesisTime uint64) *uint64 {
+	if d.L2GenesisSpanBatchTimeOffset == nil {
+		return nil
+	}
+	v := uint64(0)
+	if offset := *d.L2GenesisSpanBatchTimeOffset; offset > 0 {
+		v = genesisTime + uint64(offset)
+	}
+	return &v
+}
+
 // RollupConfig converts a DeployConfig to a rollup.Config
 func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHash common.Hash, l2GenesisBlockNumber uint64) (*rollup.Config, error) {
 	if d.OptimismPortalProxy == (common.Address{}) {
@@ -478,6 +492,7 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHas
 		DepositContractAddress: d.OptimismPortalProxy,
 		L1SystemConfigAddress:  d.SystemConfigProxy,
 		RegolithTime:           d.RegolithTime(l1StartBlock.Time()),
+		SpanBatchTime:          d.SpanBatchTime(l1StartBlock.Time()),
 	}, nil
 }
 

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -58,6 +58,7 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 	deployConfig.ChannelTimeout = tp.ChannelTimeout
 	deployConfig.L1BlockTime = tp.L1BlockTime
 	deployConfig.L2GenesisRegolithTimeOffset = nil
+	deployConfig.L2GenesisSpanBatchTimeOffset = SpanBatchTimeOffset()
 
 	require.NoError(t, deployConfig.Check())
 	require.Equal(t, addresses.Batcher, deployConfig.BatchSenderAddress)
@@ -156,6 +157,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		DepositContractAddress: deployConf.OptimismPortalProxy,
 		L1SystemConfigAddress:  deployConf.SystemConfigProxy,
 		RegolithTime:           deployConf.RegolithTime(uint64(deployConf.L1GenesisBlockTimestamp)),
+		SpanBatchTime:          deployConf.SpanBatchTime(uint64(deployConf.L1GenesisBlockTimestamp)),
 	}
 
 	require.NoError(t, rollupCfg.Check())
@@ -180,4 +182,12 @@ func SystemConfigFromDeployConfig(deployConfig *genesis.DeployConfig) eth.System
 		Scalar:      eth.Bytes32(common.BigToHash(new(big.Int).SetUint64(deployConfig.GasPriceOracleScalar))),
 		GasLimit:    uint64(deployConfig.L2GenesisBlockGasLimit),
 	}
+}
+
+func SpanBatchTimeOffset() *hexutil.Uint64 {
+	if os.Getenv("OP_E2E_USE_SPAN_BATCH") == "true" {
+		offset := hexutil.Uint64(0)
+		return &offset
+	}
+	return nil
 }

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -85,6 +85,7 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 	require.NoError(t, err)
 	deployConfig := config.DeployConfig.Copy()
 	deployConfig.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
+	deployConfig.L2GenesisSpanBatchTimeOffset = e2eutils.SpanBatchTimeOffset()
 	require.NoError(t, deployConfig.Check(), "Deploy config is invalid, do you need to run make devnet-allocs?")
 	l1Deployments := config.L1Deployments.Copy()
 	require.NoError(t, l1Deployments.Check())
@@ -418,6 +419,7 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 			DepositContractAddress:  cfg.DeployConfig.OptimismPortalProxy,
 			L1SystemConfigAddress:   cfg.DeployConfig.SystemConfigProxy,
 			RegolithTime:            cfg.DeployConfig.RegolithTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
+			SpanBatchTime:           cfg.DeployConfig.SpanBatchTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
 			ProtocolVersionsAddress: cfg.L1Deployments.ProtocolVersionsProxy,
 		}
 	}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -79,6 +79,8 @@ type Config struct {
 	// Active if CanyonTime != nil && L2 block timestamp >= *CanyonTime, inactive otherwise.
 	CanyonTime *uint64 `json:"canyon_time,omitempty"`
 
+	SpanBatchTime *uint64 `json:"span_batch_time,omitempty"`
+
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
 
@@ -268,6 +270,10 @@ func (c *Config) IsCanyon(timestamp uint64) bool {
 	return c.CanyonTime != nil && timestamp >= *c.CanyonTime
 }
 
+func (c *Config) IsSpanBatch(timestamp uint64) bool {
+	return c.SpanBatchTime != nil && timestamp >= *c.SpanBatchTime
+}
+
 // Description outputs a banner describing the important parts of rollup configuration in a human-readable form.
 // Optionally provide a mapping of L2 chain IDs to network names to label the L2 chain with if not unknown.
 // The config should be config.Check()-ed before creating a description.
@@ -296,6 +302,7 @@ func (c *Config) Description(l2Chains map[string]string) string {
 	banner += "Post-Bedrock Network Upgrades (timestamp based):\n"
 	banner += fmt.Sprintf("  - Regolith: %s\n", fmtForkTimeOrUnset(c.RegolithTime))
 	banner += fmt.Sprintf("  - Canyon: %s\n", fmtForkTimeOrUnset(c.CanyonTime))
+	banner += fmt.Sprintf("  - SpanBatch: %s\n", fmtForkTimeOrUnset(c.SpanBatchTime))
 	// Report the protocol version
 	banner += fmt.Sprintf("Node supports up to OP-Stack Protocol Version: %s\n", OPStackSupport)
 	return banner
@@ -321,7 +328,9 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l1_network", networkL1, "l2_start_time", c.Genesis.L2Time, "l2_block_hash", c.Genesis.L2.Hash.String(),
 		"l2_block_number", c.Genesis.L2.Number, "l1_block_hash", c.Genesis.L1.Hash.String(),
 		"l1_block_number", c.Genesis.L1.Number, "regolith_time", fmtForkTimeOrUnset(c.RegolithTime),
-		"canyon_time", fmtForkTimeOrUnset(c.CanyonTime))
+		"canyon_time", fmtForkTimeOrUnset(c.CanyonTime),
+		"span_batch_time", fmtForkTimeOrUnset(c.SpanBatchTime),
+	)
 }
 
 func fmtForkTimeOrUnset(v *uint64) string {

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -43,6 +43,7 @@
   "eip1559Elasticity": 6,
   "l1GenesisBlockTimestamp": "0x64c811bf",
   "l2GenesisRegolithTimeOffset": "0x0",
+  "l2GenesisSpanBatchTimeOffset": "0x0",
   "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 30,
   "faultGameMaxDuration": 1200,


### PR DESCRIPTION
## Overview

This PR contains the Hardfork configurations for the [Span Batch](https://github.com/ethereum-optimism/optimism/blob/develop/specs/span-batches.md). 

The Span Batch’s hard fork activation follows the same pattern as the Regolith hard fork. We defined a timestamp that triggers the hard fork at the op-node’s rollup.json—spanBatchTime.

Please refer to the `Hard fork` section of Implementation Design Docs for details.

## Changes

- Added `SpanBatchTime` that triggers the Span Batch hard fork.
- Added `OP_E2E_USE_SPAN_BATCH` flag that executes e2e tests with Span Batch.