### PR TITLE
op-node: Span Batch Type, Encoding, and Decoding Refactoring

### DIFF
--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -762,7 +762,7 @@ func TestFramePublished(t *testing.T) {
 }
 
 func ChannelBuilder_PendingFrames_TotalFrames(t *testing.T, batchType uint) {
-	const tnf = 8
+	const tnf = 9
 	rng := rand.New(rand.NewSource(94572314))
 	require := require.New(t)
 	cfg := defaultTestChannelConfig

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -827,7 +827,7 @@ func ChannelBuilder_InputBytes(t *testing.T, batchType uint) {
 			spanBatchBuilder.AppendSingularBatch(singularBatch)
 			rawSpanBatch, err := spanBatchBuilder.GetRawSpanBatch()
 			require.NoError(err)
-			batch := derive.NewSpanBatchData(*rawSpanBatch)
+			batch := derive.NewBatchData(rawSpanBatch)
 			var buf bytes.Buffer
 			require.NoError(batch.EncodeRLP(&buf))
 			l = buf.Len()
@@ -877,7 +877,7 @@ func ChannelBuilder_OutputBytes(t *testing.T, batchType uint) {
 func blockBatchRlpSize(t *testing.T, b *types.Block) int {
 	t.Helper()
 	singularBatch, _, err := derive.BlockToSingularBatch(b)
-	batch := derive.NewSingularBatchData(*singularBatch)
+	batch := derive.NewBatchData(singularBatch)
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	require.NoError(t, batch.EncodeRLP(&buf), "RLP-encoding batch")

--- a/op-e2e/actions/garbage_channel_out.go
+++ b/op-e2e/actions/garbage_channel_out.go
@@ -252,13 +252,13 @@ func blockToBatch(block *types.Block) (*derive.BatchData, error) {
 		return nil, fmt.Errorf("could not parse the L1 Info deposit: %w", err)
 	}
 
-	return &derive.BatchData{
-		SingularBatch: derive.SingularBatch{
-			ParentHash:   block.ParentHash(),
-			EpochNum:     rollup.Epoch(l1Info.Number),
-			EpochHash:    l1Info.BlockHash,
-			Timestamp:    block.Time(),
-			Transactions: opaqueTxs,
-		},
-	}, nil
+	singularBatch := &derive.SingularBatch{
+		ParentHash:   block.ParentHash(),
+		EpochNum:     rollup.Epoch(l1Info.Number),
+		EpochHash:    l1Info.BlockHash,
+		Timestamp:    block.Time(),
+		Transactions: opaqueTxs,
+	}
+
+	return derive.NewBatchData(singularBatch), nil
 }

--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -16,12 +16,12 @@ import (
 )
 
 type ChannelWithMetadata struct {
-	ID             derive.ChannelID       `json:"id"`
-	IsReady        bool                   `json:"is_ready"`
-	InvalidFrames  bool                   `json:"invalid_frames"`
-	InvalidBatches bool                   `json:"invalid_batches"`
-	Frames         []FrameWithMetadata    `json:"frames"`
-	Batches        []derive.SingularBatch `json:"batches"`
+	ID             derive.ChannelID    `json:"id"`
+	IsReady        bool                `json:"is_ready"`
+	InvalidFrames  bool                `json:"invalid_frames"`
+	InvalidBatches bool                `json:"invalid_batches"`
+	Frames         []FrameWithMetadata `json:"frames"`
+	Batches        []derive.BatchData  `json:"batches"`
 }
 
 type FrameWithMetadata struct {
@@ -100,7 +100,7 @@ func processFrames(id derive.ChannelID, frames []FrameWithMetadata) ChannelWithM
 		}
 	}
 
-	var batches []derive.SingularBatch
+	var batches []derive.BatchData
 	invalidBatches := false
 	if ch.IsReady() {
 		br, err := derive.BatchReader(ch.Reader())
@@ -110,7 +110,7 @@ func processFrames(id derive.ChannelID, frames []FrameWithMetadata) ChannelWithM
 					fmt.Printf("Error reading batch for channel %v. Err: %v\n", id.String(), err)
 					invalidBatches = true
 				} else {
-					batches = append(batches, batch.SingularBatch)
+					batches = append(batches, *batch)
 				}
 			}
 		} else {

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -25,9 +25,9 @@ var encodeBufferPool = sync.Pool{
 
 const (
 	// SingularBatchType is the first version of Batch format, representing a single L2 block.
-	SingularBatchType = iota
+	SingularBatchType = 0
 	// SpanBatchType is the Batch version used after SpanBatch hard fork, representing a span of L2 blocks.
-	SpanBatchType
+	SpanBatchType = 1
 )
 
 // Batch contains information to build one or multiple L2 blocks.

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -40,7 +40,9 @@ type Batch interface {
 }
 
 // BatchData is used to represent the typed encoding & decoding.
-// and wraps arount a single interface InnerBatchData.
+// and wraps around a single interface InnerBatchData.
+// Further fields such as cache can be added in the future, without embedding each type of InnerBatchData.
+// Similar design with op-geth's types.Transaction struct.
 type BatchData struct {
 	inner InnerBatchData
 }

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -166,17 +166,17 @@ func TestBatchRoundTrip(t *testing.T) {
 
 	for i, batch := range batches {
 		enc, err := batch.MarshalBinary()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		var dec BatchData
 		err = dec.UnmarshalBinary(enc)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if dec.GetBatchType() == SpanBatchType {
 			rawSpanBatch, ok := dec.inner.(*RawSpanBatch)
-			assert.True(t, ok)
+			require.True(t, ok)
 			_, err := rawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
-		assert.Equal(t, batch, &dec, "Batch not equal test case %v", i)
+		require.Equal(t, batch, &dec, "Batch not equal test case %v", i)
 	}
 }
 
@@ -213,19 +213,19 @@ func TestBatchRoundTripRLP(t *testing.T) {
 	for i, batch := range batches {
 		var buf bytes.Buffer
 		err := batch.EncodeRLP(&buf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		result := buf.Bytes()
 		var dec BatchData
 		r := bytes.NewReader(result)
 		s := rlp.NewStream(r, 0)
 		err = dec.DecodeRLP(s)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if dec.GetBatchType() == SpanBatchType {
 			rawSpanBatch, ok := dec.inner.(*RawSpanBatch)
-			assert.True(t, ok)
+			require.True(t, ok)
 			_, err := rawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
-		assert.Equal(t, batch, &dec, "Batch not equal test case %v", i)
+		require.Equal(t, batch, &dec, "Batch not equal test case %v", i)
 	}
 }

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -52,8 +52,8 @@ func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
 		spanBatchPrefix: spanBatchPrefix{
 			relTimestamp:  uint64(rng.Uint32()),
 			l1OriginNum:   rng.Uint64(),
-			parentCheck:   testutils.RandomData(rng, 20),
-			l1OriginCheck: testutils.RandomData(rng, 20),
+			parentCheck:   [20]byte(testutils.RandomData(rng, 20)),
+			l1OriginCheck: [20]byte(testutils.RandomData(rng, 20)),
 		},
 		spanBatchPayload: spanBatchPayload{
 			blockCount:    blockCount,

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -141,27 +141,27 @@ func TestBatchRoundTrip(t *testing.T) {
 	chainID := new(big.Int).SetUint64(rng.Uint64())
 
 	batches := []*BatchData{
-		{
-			SingularBatch: SingularBatch{
+		NewBatchData(
+			&SingularBatch{
 				ParentHash:   common.Hash{},
 				EpochNum:     0,
 				Timestamp:    0,
 				Transactions: []hexutil.Bytes{},
 			},
-		},
-		{
-			SingularBatch: SingularBatch{
+		),
+		NewBatchData(
+			&SingularBatch{
 				ParentHash:   common.Hash{31: 0x42},
 				EpochNum:     1,
 				Timestamp:    1647026951,
 				Transactions: []hexutil.Bytes{[]byte{0, 0, 0}, []byte{0x76, 0xfd, 0x7c}},
 			},
-		},
-		NewSingularBatchData(*RandomSingularBatch(rng, 5, chainID)),
-		NewSingularBatchData(*RandomSingularBatch(rng, 7, chainID)),
-		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
-		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
-		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
+		),
+		NewBatchData(RandomSingularBatch(rng, 5, chainID)),
+		NewBatchData(RandomSingularBatch(rng, 7, chainID)),
+		NewBatchData(RandomRawSpanBatch(rng, chainID)),
+		NewBatchData(RandomRawSpanBatch(rng, chainID)),
+		NewBatchData(RandomRawSpanBatch(rng, chainID)),
 	}
 
 	for i, batch := range batches {
@@ -170,8 +170,10 @@ func TestBatchRoundTrip(t *testing.T) {
 		var dec BatchData
 		err = dec.UnmarshalBinary(enc)
 		assert.NoError(t, err)
-		if dec.BatchType == SpanBatchType {
-			_, err := dec.RawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
+		if dec.GetBatchType() == SpanBatchType {
+			rawSpanBatch, ok := dec.inner.(*RawSpanBatch)
+			assert.True(t, ok)
+			_, err := rawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
 			assert.NoError(t, err)
 		}
 		assert.Equal(t, batch, &dec, "Batch not equal test case %v", i)
@@ -185,27 +187,27 @@ func TestBatchRoundTripRLP(t *testing.T) {
 	chainID := new(big.Int).SetUint64(rng.Uint64())
 
 	batches := []*BatchData{
-		{
-			SingularBatch: SingularBatch{
+		NewBatchData(
+			&SingularBatch{
 				ParentHash:   common.Hash{},
 				EpochNum:     0,
 				Timestamp:    0,
 				Transactions: []hexutil.Bytes{},
 			},
-		},
-		{
-			SingularBatch: SingularBatch{
+		),
+		NewBatchData(
+			&SingularBatch{
 				ParentHash:   common.Hash{31: 0x42},
 				EpochNum:     1,
 				Timestamp:    1647026951,
 				Transactions: []hexutil.Bytes{[]byte{0, 0, 0}, []byte{0x76, 0xfd, 0x7c}},
 			},
-		},
-		NewSingularBatchData(*RandomSingularBatch(rng, 5, chainID)),
-		NewSingularBatchData(*RandomSingularBatch(rng, 7, chainID)),
-		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
-		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
-		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
+		),
+		NewBatchData(RandomSingularBatch(rng, 5, chainID)),
+		NewBatchData(RandomSingularBatch(rng, 7, chainID)),
+		NewBatchData(RandomRawSpanBatch(rng, chainID)),
+		NewBatchData(RandomRawSpanBatch(rng, chainID)),
+		NewBatchData(RandomRawSpanBatch(rng, chainID)),
 	}
 
 	for i, batch := range batches {
@@ -218,8 +220,10 @@ func TestBatchRoundTripRLP(t *testing.T) {
 		s := rlp.NewStream(r, 0)
 		err = dec.DecodeRLP(s)
 		assert.NoError(t, err)
-		if dec.BatchType == SpanBatchType {
-			_, err := dec.RawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
+		if dec.GetBatchType() == SpanBatchType {
+			rawSpanBatch, ok := dec.inner.(*RawSpanBatch)
+			assert.True(t, ok)
+			_, err := rawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
 			assert.NoError(t, err)
 		}
 		assert.Equal(t, batch, &dec, "Batch not equal test case %v", i)

--- a/op-node/rollup/derive/batch_tob_test.go
+++ b/op-node/rollup/derive/batch_tob_test.go
@@ -17,13 +17,13 @@ func FuzzBatchRoundTrip(f *testing.F) {
 		typeProvider := fuzz.NewFromGoFuzz(fuzzedData).NilChance(0).MaxDepth(10000).NumElements(0, 0x100).AllowUnexportedFields(true)
 		fuzzerutils.AddFuzzerFunctions(typeProvider)
 
+		var singularBatch SingularBatch
+		typeProvider.Fuzz(&singularBatch)
+
 		// Create our batch data from fuzzed data
 		var batchData BatchData
-		typeProvider.Fuzz(&batchData)
-
 		// force batchdata to only contain singular batch
-		batchData.BatchType = SingularBatchType
-		batchData.RawSpanBatch = RawSpanBatch{}
+		batchData.inner = &singularBatch
 
 		// Encode our batch data
 		enc, err := batchData.MarshalBinary()

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -159,7 +159,7 @@ func (co *ChannelOut) writeSingularBatch(batch *SingularBatch) (uint64, error) {
 	var buf bytes.Buffer
 	// We encode to a temporary buffer to determine the encoded length to
 	// ensure that the total size of all RLP elements is less than or equal to MAX_RLP_BYTES_PER_CHANNEL
-	if err := rlp.Encode(&buf, NewSingularBatchData(*batch)); err != nil {
+	if err := rlp.Encode(&buf, NewBatchData(batch)); err != nil {
 		return 0, err
 	}
 	if co.rlpLength+buf.Len() > MaxRLPBytesPerChannel {
@@ -191,7 +191,7 @@ func (co *ChannelOut) writeSpanBatch(batch *SingularBatch) (uint64, error) {
 		return 0, fmt.Errorf("failed to convert SpanBatch into RawSpanBatch: %w", err)
 	}
 	// Encode RawSpanBatch into bytes
-	if err = rlp.Encode(&buf, NewSpanBatchData(*rawSpanBatch)); err != nil {
+	if err = rlp.Encode(&buf, NewBatchData(rawSpanBatch)); err != nil {
 		return 0, fmt.Errorf("failed to encode RawSpanBatch into bytes: %w", err)
 	}
 	co.rlpLength = 0

--- a/op-node/rollup/derive/singular_batch.go
+++ b/op-node/rollup/derive/singular_batch.go
@@ -1,11 +1,15 @@
 package derive
 
 import (
+	"bytes"
+	"io"
+
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // Batch format
@@ -50,4 +54,24 @@ func (b *SingularBatch) LogContext(log log.Logger) log.Logger {
 // Epoch returns a BlockID of its L1 origin.
 func (b *SingularBatch) Epoch() eth.BlockID {
 	return eth.BlockID{Hash: b.EpochHash, Number: uint64(b.EpochNum)}
+}
+
+// encode writes the byte encoding of SingularBatch to Writer stream
+func (b *SingularBatch) encode(w io.Writer) error {
+	return rlp.Encode(w, b)
+}
+
+// decode reads the byte encoding of SingularBatch from Reader stream
+func (b *SingularBatch) decode(r *bytes.Reader) error {
+	return rlp.Decode(r, b)
+}
+
+// encodeBytes returns the byte encoding of SingularBatch
+func (b *SingularBatch) encodeBytes() ([]byte, error) {
+	return rlp.EncodeToBytes(b)
+}
+
+// decodeBytes parses data into b from data
+func (b *SingularBatch) decodeBytes(data []byte) error {
+	return rlp.DecodeBytes(data, b)
 }

--- a/op-node/rollup/derive/singular_batch_test.go
+++ b/op-node/rollup/derive/singular_batch_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSingularBatchForBatchInterface(t *testing.T) {
@@ -15,7 +15,7 @@ func TestSingularBatchForBatchInterface(t *testing.T) {
 
 	singularBatch := RandomSingularBatch(rng, txCount, chainID)
 
-	assert.Equal(t, SingularBatchType, singularBatch.GetBatchType())
-	assert.Equal(t, singularBatch.Timestamp, singularBatch.GetTimestamp())
-	assert.Equal(t, singularBatch.EpochNum, singularBatch.GetEpochNum())
+	require.Equal(t, SingularBatchType, singularBatch.GetBatchType())
+	require.Equal(t, singularBatch.Timestamp, singularBatch.GetTimestamp())
+	require.Equal(t, singularBatch.EpochNum, singularBatch.GetEpochNum())
 }

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -47,6 +47,11 @@ type RawSpanBatch struct {
 	spanBatchPayload
 }
 
+// GetBatchType returns its batch type (batch_version)
+func (b *RawSpanBatch) GetBatchType() int {
+	return SpanBatchType
+}
+
 // decodeOriginBits parses data into bp.originBits
 // originBits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
@@ -200,6 +205,11 @@ func (bp *spanBatchPayload) decodePayload(r *bytes.Reader) error {
 // decodeBytes parses data into b from data
 func (b *RawSpanBatch) decodeBytes(data []byte) error {
 	r := bytes.NewReader(data)
+	return b.decode(r)
+}
+
+// decode reads the byte encoding of SpanBatch from Reader stream
+func (b *RawSpanBatch) decode(r *bytes.Reader) error {
 	if err := b.decodePrefix(r); err != nil {
 		return err
 	}

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -290,8 +290,8 @@ func TestSpanBatchDerive(t *testing.T) {
 		assert.NoError(t, err)
 
 		blockCount := len(singularBatches)
-		assert.Equal(t, safeL2Head.Hash.Bytes()[:20], spanBatchDerived.parentCheck)
-		assert.Equal(t, singularBatches[blockCount-1].Epoch().Hash.Bytes()[:20], spanBatchDerived.l1OriginCheck)
+		assert.Equal(t, safeL2Head.Hash.Bytes()[:20], spanBatchDerived.parentCheck[:])
+		assert.Equal(t, singularBatches[blockCount-1].Epoch().Hash.Bytes()[:20], spanBatchDerived.l1OriginCheck[:])
 		assert.Equal(t, len(singularBatches), int(rawSpanBatch.blockCount))
 
 		for i := 1; i < len(singularBatches); i++ {
@@ -343,8 +343,8 @@ func TestSpanBatchMerge(t *testing.T) {
 		// check span batch prefix
 		assert.Equal(t, rawSpanBatch.relTimestamp, singularBatches[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
 		assert.Equal(t, rollup.Epoch(rawSpanBatch.l1OriginNum), singularBatches[blockCount-1].EpochNum)
-		assert.Equal(t, rawSpanBatch.parentCheck, singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
-		assert.Equal(t, rawSpanBatch.l1OriginCheck, singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
+		assert.Equal(t, rawSpanBatch.parentCheck[:], singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
+		assert.Equal(t, rawSpanBatch.l1OriginCheck[:], singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
 
 		// check span batch payload
 		assert.Equal(t, int(rawSpanBatch.blockCount), len(singularBatches))
@@ -468,8 +468,8 @@ func TestSpanBatchBuilder(t *testing.T) {
 		for i := 0; i < len(singularBatches); i++ {
 			spanBatchBuilder.AppendSingularBatch(singularBatches[i])
 			assert.Equal(t, i+1, spanBatchBuilder.GetBlockCount())
-			assert.Equal(t, singularBatches[0].ParentHash.Bytes()[:20], spanBatchBuilder.spanBatch.parentCheck)
-			assert.Equal(t, singularBatches[i].EpochHash.Bytes()[:20], spanBatchBuilder.spanBatch.l1OriginCheck)
+			assert.Equal(t, singularBatches[0].ParentHash.Bytes()[:20], spanBatchBuilder.spanBatch.parentCheck[:])
+			assert.Equal(t, singularBatches[i].EpochHash.Bytes()[:20], spanBatchBuilder.spanBatch.l1OriginCheck[:])
 		}
 
 		rawSpanBatch, err := spanBatchBuilder.GetRawSpanBatch()

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpanBatchForBatchInterface(t *testing.T) {
@@ -26,11 +26,11 @@ func TestSpanBatchForBatchInterface(t *testing.T) {
 	spanBatch := NewSpanBatch(singularBatches)
 
 	// check interface method implementations except logging
-	assert.Equal(t, SpanBatchType, spanBatch.GetBatchType())
-	assert.Equal(t, singularBatches[0].Timestamp, spanBatch.GetTimestamp())
-	assert.Equal(t, singularBatches[0].EpochNum, spanBatch.GetStartEpochNum())
-	assert.True(t, spanBatch.CheckOriginHash(singularBatches[blockCount-1].EpochHash))
-	assert.True(t, spanBatch.CheckParentHash(singularBatches[0].ParentHash))
+	require.Equal(t, SpanBatchType, spanBatch.GetBatchType())
+	require.Equal(t, singularBatches[0].Timestamp, spanBatch.GetTimestamp())
+	require.Equal(t, singularBatches[0].EpochNum, spanBatch.GetStartEpochNum())
+	require.True(t, spanBatch.CheckOriginHash(singularBatches[blockCount-1].EpochHash))
+	require.True(t, spanBatch.CheckParentHash(singularBatches[0].ParentHash))
 }
 
 func TestSpanBatchOriginBits(t *testing.T) {
@@ -43,23 +43,23 @@ func TestSpanBatchOriginBits(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeOriginBits(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// originBit field is fixed length: single bit
 	originBitBufferLen := blockCount / 8
 	if blockCount%8 != 0 {
 		originBitBufferLen++
 	}
-	assert.Equal(t, buf.Len(), int(originBitBufferLen))
+	require.Equal(t, buf.Len(), int(originBitBufferLen))
 
 	result := buf.Bytes()
 	var sb RawSpanBatch
 	sb.blockCount = blockCount
 	r := bytes.NewReader(result)
 	err = sb.decodeOriginBits(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, rawSpanBatch.originBits, sb.originBits)
+	require.Equal(t, rawSpanBatch.originBits, sb.originBits)
 }
 
 func TestSpanBatchPrefix(t *testing.T) {
@@ -72,15 +72,15 @@ func TestSpanBatchPrefix(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodePrefix(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 	err = sb.decodePrefix(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, rawSpanBatch, &sb)
+	require.Equal(t, rawSpanBatch, &sb)
 }
 
 func TestSpanBatchRelTimestamp(t *testing.T) {
@@ -91,15 +91,15 @@ func TestSpanBatchRelTimestamp(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeRelTimestamp(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 	err = sb.decodeRelTimestamp(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, rawSpanBatch.relTimestamp, sb.relTimestamp)
+	require.Equal(t, rawSpanBatch.relTimestamp, sb.relTimestamp)
 }
 
 func TestSpanBatchL1OriginNum(t *testing.T) {
@@ -110,15 +110,15 @@ func TestSpanBatchL1OriginNum(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeL1OriginNum(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 	err = sb.decodeL1OriginNum(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, rawSpanBatch.l1OriginNum, sb.l1OriginNum)
+	require.Equal(t, rawSpanBatch.l1OriginNum, sb.l1OriginNum)
 }
 
 func TestSpanBatchParentCheck(t *testing.T) {
@@ -129,18 +129,18 @@ func TestSpanBatchParentCheck(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeParentCheck(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// parent check field is fixed length: 20 bytes
-	assert.Equal(t, buf.Len(), 20)
+	require.Equal(t, buf.Len(), 20)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 	err = sb.decodeParentCheck(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, rawSpanBatch.parentCheck, sb.parentCheck)
+	require.Equal(t, rawSpanBatch.parentCheck, sb.parentCheck)
 }
 
 func TestSpanBatchL1OriginCheck(t *testing.T) {
@@ -151,18 +151,18 @@ func TestSpanBatchL1OriginCheck(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeL1OriginCheck(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// l1 origin check field is fixed length: 20 bytes
-	assert.Equal(t, buf.Len(), 20)
+	require.Equal(t, buf.Len(), 20)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 	err = sb.decodeL1OriginCheck(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, rawSpanBatch.l1OriginCheck, sb.l1OriginCheck)
+	require.Equal(t, rawSpanBatch.l1OriginCheck, sb.l1OriginCheck)
 }
 
 func TestSpanBatchPayload(t *testing.T) {
@@ -173,18 +173,18 @@ func TestSpanBatchPayload(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodePayload(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 
 	err = sb.decodePayload(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sb.txs.recoverV(chainID)
 
-	assert.Equal(t, rawSpanBatch.spanBatchPayload, sb.spanBatchPayload)
+	require.Equal(t, rawSpanBatch.spanBatchPayload, sb.spanBatchPayload)
 }
 
 func TestSpanBatchBlockCount(t *testing.T) {
@@ -195,16 +195,16 @@ func TestSpanBatchBlockCount(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeBlockCount(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 
 	err = sb.decodeBlockCount(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, rawSpanBatch.blockCount, sb.blockCount)
+	require.Equal(t, rawSpanBatch.blockCount, sb.blockCount)
 }
 
 func TestSpanBatchBlockTxCounts(t *testing.T) {
@@ -215,7 +215,7 @@ func TestSpanBatchBlockTxCounts(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeBlockTxCounts(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
@@ -223,9 +223,9 @@ func TestSpanBatchBlockTxCounts(t *testing.T) {
 
 	sb.blockCount = rawSpanBatch.blockCount
 	err = sb.decodeBlockTxCounts(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, rawSpanBatch.blockTxCounts, sb.blockTxCounts)
+	require.Equal(t, rawSpanBatch.blockTxCounts, sb.blockTxCounts)
 }
 
 func TestSpanBatchTxs(t *testing.T) {
@@ -236,7 +236,7 @@ func TestSpanBatchTxs(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeTxs(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
@@ -244,11 +244,11 @@ func TestSpanBatchTxs(t *testing.T) {
 
 	sb.blockTxCounts = rawSpanBatch.blockTxCounts
 	err = sb.decodeTxs(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sb.txs.recoverV(chainID)
 
-	assert.Equal(t, rawSpanBatch.txs, sb.txs)
+	require.Equal(t, rawSpanBatch.txs, sb.txs)
 }
 
 func TestSpanBatchRoundTrip(t *testing.T) {
@@ -258,15 +258,15 @@ func TestSpanBatchRoundTrip(t *testing.T) {
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
 
 	result, err := rawSpanBatch.encodeBytes()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var sb RawSpanBatch
 	err = sb.decodeBytes(result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sb.txs.recoverV(chainID)
 
-	assert.Equal(t, rawSpanBatch, &sb)
+	require.Equal(t, rawSpanBatch, &sb)
 }
 
 func TestSpanBatchDerive(t *testing.T) {
@@ -284,24 +284,24 @@ func TestSpanBatchDerive(t *testing.T) {
 		spanBatch := NewSpanBatch(singularBatches)
 		originChangedBit := uint(originChangedBit)
 		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		spanBatchDerived, err := rawSpanBatch.derive(l2BlockTime, genesisTimeStamp, chainID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		blockCount := len(singularBatches)
-		assert.Equal(t, safeL2Head.Hash.Bytes()[:20], spanBatchDerived.parentCheck[:])
-		assert.Equal(t, singularBatches[blockCount-1].Epoch().Hash.Bytes()[:20], spanBatchDerived.l1OriginCheck[:])
-		assert.Equal(t, len(singularBatches), int(rawSpanBatch.blockCount))
+		require.Equal(t, safeL2Head.Hash.Bytes()[:20], spanBatchDerived.parentCheck[:])
+		require.Equal(t, singularBatches[blockCount-1].Epoch().Hash.Bytes()[:20], spanBatchDerived.l1OriginCheck[:])
+		require.Equal(t, len(singularBatches), int(rawSpanBatch.blockCount))
 
 		for i := 1; i < len(singularBatches); i++ {
-			assert.Equal(t, spanBatchDerived.batches[i].Timestamp, spanBatchDerived.batches[i-1].Timestamp+l2BlockTime)
+			require.Equal(t, spanBatchDerived.batches[i].Timestamp, spanBatchDerived.batches[i-1].Timestamp+l2BlockTime)
 		}
 
 		for i := 0; i < len(singularBatches); i++ {
-			assert.Equal(t, singularBatches[i].EpochNum, spanBatchDerived.batches[i].EpochNum)
-			assert.Equal(t, singularBatches[i].Timestamp, spanBatchDerived.batches[i].Timestamp)
-			assert.Equal(t, singularBatches[i].Transactions, spanBatchDerived.batches[i].Transactions)
+			require.Equal(t, singularBatches[i].EpochNum, spanBatchDerived.batches[i].EpochNum)
+			require.Equal(t, singularBatches[i].Timestamp, spanBatchDerived.batches[i].Timestamp)
+			require.Equal(t, singularBatches[i].Transactions, spanBatchDerived.batches[i].Transactions)
 		}
 	}
 }
@@ -322,7 +322,7 @@ func TestSpanBatchAppend(t *testing.T) {
 	// initialize with two singular batches
 	spanBatch2 := NewSpanBatch(singularBatches[:L])
 
-	assert.Equal(t, spanBatch, spanBatch2)
+	require.Equal(t, spanBatch, spanBatch2)
 }
 
 func TestSpanBatchMerge(t *testing.T) {
@@ -338,32 +338,32 @@ func TestSpanBatchMerge(t *testing.T) {
 		spanBatch := NewSpanBatch(singularBatches)
 		originChangedBit := uint(originChangedBit)
 		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// check span batch prefix
-		assert.Equal(t, rawSpanBatch.relTimestamp, singularBatches[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
-		assert.Equal(t, rollup.Epoch(rawSpanBatch.l1OriginNum), singularBatches[blockCount-1].EpochNum)
-		assert.Equal(t, rawSpanBatch.parentCheck[:], singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
-		assert.Equal(t, rawSpanBatch.l1OriginCheck[:], singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
+		require.Equal(t, rawSpanBatch.relTimestamp, singularBatches[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
+		require.Equal(t, rollup.Epoch(rawSpanBatch.l1OriginNum), singularBatches[blockCount-1].EpochNum)
+		require.Equal(t, rawSpanBatch.parentCheck[:], singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
+		require.Equal(t, rawSpanBatch.l1OriginCheck[:], singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
 
 		// check span batch payload
-		assert.Equal(t, int(rawSpanBatch.blockCount), len(singularBatches))
-		assert.Equal(t, rawSpanBatch.originBits.Bit(0), originChangedBit)
+		require.Equal(t, int(rawSpanBatch.blockCount), len(singularBatches))
+		require.Equal(t, rawSpanBatch.originBits.Bit(0), originChangedBit)
 		for i := 1; i < blockCount; i++ {
 			if rawSpanBatch.originBits.Bit(i) == 1 {
-				assert.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum+1)
+				require.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum+1)
 			} else {
-				assert.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum)
+				require.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum)
 			}
 		}
 		for i := 0; i < len(singularBatches); i++ {
 			txCount := len(singularBatches[i].Transactions)
-			assert.Equal(t, txCount, int(rawSpanBatch.blockTxCounts[i]))
+			require.Equal(t, txCount, int(rawSpanBatch.blockTxCounts[i]))
 		}
 
 		// check invariants
 		endEpochNum := rawSpanBatch.l1OriginNum
-		assert.Equal(t, endEpochNum, uint64(singularBatches[blockCount-1].EpochNum))
+		require.Equal(t, endEpochNum, uint64(singularBatches[blockCount-1].EpochNum))
 
 		// we do not check txs field because it has to be derived to be compared
 	}
@@ -383,12 +383,12 @@ func TestSpanBatchToSingularBatch(t *testing.T) {
 		spanBatch := NewSpanBatch(singularBatches)
 		originChangedBit := uint(originChangedBit)
 		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		l1Origins := mockL1Origin(rng, rawSpanBatch, singularBatches)
 
 		singularBatches2, err := spanBatch.GetSingularBatches(l1Origins, safeL2Head)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// GetSingularBatches does not fill in parent hash of singular batches
 		// empty out parent hash for comparison
@@ -397,10 +397,10 @@ func TestSpanBatchToSingularBatch(t *testing.T) {
 		}
 		// check parent hash is empty
 		for i := 0; i < len(singularBatches2); i++ {
-			assert.Equal(t, singularBatches2[i].ParentHash, common.Hash{})
+			require.Equal(t, singularBatches2[i].ParentHash, common.Hash{})
 		}
 
-		assert.Equal(t, singularBatches, singularBatches2)
+		require.Equal(t, singularBatches, singularBatches2)
 	}
 }
 
@@ -418,7 +418,7 @@ func TestSpanBatchReadTxData(t *testing.T) {
 		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
 		m[tx.Type()] += 1
 		rawTx, err := tx.MarshalBinary()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		rawTxs = append(rawTxs, rawTx)
 		txs = append(txs, tx)
 	}
@@ -426,23 +426,23 @@ func TestSpanBatchReadTxData(t *testing.T) {
 	for i := 0; i < txCount; i++ {
 		r := bytes.NewReader(rawTxs[i])
 		_, txType, err := ReadTxData(r)
-		assert.NoError(t, err)
-		assert.Equal(t, int(txs[i].Type()), txType)
+		require.NoError(t, err)
+		require.Equal(t, int(txs[i].Type()), txType)
 	}
 	// make sure every tx type is tested
-	assert.Positive(t, m[types.LegacyTxType])
-	assert.Positive(t, m[types.AccessListTxType])
-	assert.Positive(t, m[types.DynamicFeeTxType])
+	require.Positive(t, m[types.LegacyTxType])
+	require.Positive(t, m[types.AccessListTxType])
+	require.Positive(t, m[types.DynamicFeeTxType])
 }
 
 func TestSpanBatchReadTxDataInvalid(t *testing.T) {
 	dummy, err := rlp.EncodeToBytes("dummy")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// test non list rlp decoding
 	r := bytes.NewReader(dummy)
 	_, _, err = ReadTxData(r)
-	assert.ErrorContains(t, err, "tx RLP prefix type must be list")
+	require.ErrorContains(t, err, "tx RLP prefix type must be list")
 }
 
 func TestSpanBatchBuilder(t *testing.T) {
@@ -463,28 +463,28 @@ func TestSpanBatchBuilder(t *testing.T) {
 		}
 		spanBatchBuilder := NewSpanBatchBuilder(parentEpoch, genesisTimeStamp, chainID)
 
-		assert.Equal(t, 0, spanBatchBuilder.GetBlockCount())
+		require.Equal(t, 0, spanBatchBuilder.GetBlockCount())
 
 		for i := 0; i < len(singularBatches); i++ {
 			spanBatchBuilder.AppendSingularBatch(singularBatches[i])
-			assert.Equal(t, i+1, spanBatchBuilder.GetBlockCount())
-			assert.Equal(t, singularBatches[0].ParentHash.Bytes()[:20], spanBatchBuilder.spanBatch.parentCheck[:])
-			assert.Equal(t, singularBatches[i].EpochHash.Bytes()[:20], spanBatchBuilder.spanBatch.l1OriginCheck[:])
+			require.Equal(t, i+1, spanBatchBuilder.GetBlockCount())
+			require.Equal(t, singularBatches[0].ParentHash.Bytes()[:20], spanBatchBuilder.spanBatch.parentCheck[:])
+			require.Equal(t, singularBatches[i].EpochHash.Bytes()[:20], spanBatchBuilder.spanBatch.l1OriginCheck[:])
 		}
 
 		rawSpanBatch, err := spanBatchBuilder.GetRawSpanBatch()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// compare with rawSpanBatch not using spanBatchBuilder
 		spanBatch := NewSpanBatch(singularBatches)
 		originChangedBit := uint(originChangedBit)
 		rawSpanBatch2, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.Equal(t, rawSpanBatch2, rawSpanBatch)
+		require.Equal(t, rawSpanBatch2, rawSpanBatch)
 
 		spanBatchBuilder.Reset()
-		assert.Equal(t, 0, spanBatchBuilder.GetBlockCount())
+		require.Equal(t, 0, spanBatchBuilder.GetBlockCount())
 	}
 }
 
@@ -496,12 +496,12 @@ func TestSpanBatchMaxTxData(t *testing.T) {
 	})
 
 	txEncoded, err := invalidTx.MarshalBinary()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r := bytes.NewReader(txEncoded)
 	_, _, err = ReadTxData(r)
 
-	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
 }
 
 func TestSpanBatchMaxOriginBitsLength(t *testing.T) {
@@ -510,5 +510,5 @@ func TestSpanBatchMaxOriginBitsLength(t *testing.T) {
 
 	r := bytes.NewReader([]byte{})
 	err := sb.decodeOriginBits(r)
-	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
 }

--- a/op-node/rollup/derive/span_batch_tx_test.go
+++ b/op-node/rollup/derive/span_batch_tx_test.go
@@ -1,14 +1,12 @@
 package derive
 
 import (
-	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,37 +57,6 @@ func TestSpanBatchTxRoundTrip(t *testing.T) {
 
 		var sbtx2 spanBatchTx
 		err = sbtx2.UnmarshalBinary(sbtxEncoded)
-		assert.NoError(t, err)
-
-		assert.Equal(t, sbtx, &sbtx2)
-	}
-	// make sure every tx type is tested
-	assert.Positive(t, m[types.LegacyTxType])
-	assert.Positive(t, m[types.AccessListTxType])
-	assert.Positive(t, m[types.DynamicFeeTxType])
-}
-
-func TestSpanBatchTxRoundTripRLP(t *testing.T) {
-	rng := rand.New(rand.NewSource(0x1333))
-	chainID := big.NewInt(rng.Int63n(1000))
-	signer := types.NewLondonSigner(chainID)
-
-	m := make(map[byte]int)
-	for i := 0; i < 32; i++ {
-		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
-		m[tx.Type()] += 1
-		sbtx, err := newSpanBatchTx(*tx)
-		assert.NoError(t, err)
-
-		var buf bytes.Buffer
-		err = sbtx.EncodeRLP(&buf)
-		assert.NoError(t, err)
-
-		result := buf.Bytes()
-		var sbtx2 spanBatchTx
-		r := bytes.NewReader(result)
-		rlpReader := rlp.NewStream(r, 0)
-		err = sbtx2.DecodeRLP(rlpReader)
 		assert.NoError(t, err)
 
 		assert.Equal(t, sbtx, &sbtx2)

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpanBatchTxsContractCreationBits(t *testing.T) {
@@ -26,23 +26,23 @@ func TestSpanBatchTxsContractCreationBits(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := sbt.encodeContractCreationBits(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// contractCreationBit field is fixed length: single bit
 	contractCreationBitBufferLen := totalBlockTxCount / 8
 	if totalBlockTxCount%8 != 0 {
 		contractCreationBitBufferLen++
 	}
-	assert.Equal(t, buf.Len(), int(contractCreationBitBufferLen))
+	require.Equal(t, buf.Len(), int(contractCreationBitBufferLen))
 
 	result := buf.Bytes()
 	sbt.contractCreationBits = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeContractCreationBits(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, contractCreationBits, sbt.contractCreationBits)
+	require.Equal(t, contractCreationBits, sbt.contractCreationBits)
 }
 
 func TestSpanBatchTxsContractCreationCount(t *testing.T) {
@@ -61,16 +61,16 @@ func TestSpanBatchTxsContractCreationCount(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := sbt.encodeContractCreationBits(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	sbt.contractCreationBits = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeContractCreationBits(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, contractCreationCount, sbt.contractCreationCount())
+	require.Equal(t, contractCreationCount, sbt.contractCreationCount())
 }
 
 func TestSpanBatchTxsYParityBits(t *testing.T) {
@@ -87,23 +87,23 @@ func TestSpanBatchTxsYParityBits(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := sbt.encodeYParityBits(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// yParityBit field is fixed length: single bit
 	yParityBitBufferLen := totalBlockTxCount / 8
 	if totalBlockTxCount%8 != 0 {
 		yParityBitBufferLen++
 	}
-	assert.Equal(t, buf.Len(), int(yParityBitBufferLen))
+	require.Equal(t, buf.Len(), int(yParityBitBufferLen))
 
 	result := buf.Bytes()
 	sbt.yParityBits = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeYParityBits(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, yParityBits, sbt.yParityBits)
+	require.Equal(t, yParityBits, sbt.yParityBits)
 }
 
 func TestSpanBatchTxsTxSigs(t *testing.T) {
@@ -120,22 +120,22 @@ func TestSpanBatchTxsTxSigs(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxSigsRS(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// txSig field is fixed length: 32 byte + 32 byte = 64 byte
-	assert.Equal(t, buf.Len(), 64*int(totalBlockTxCount))
+	require.Equal(t, buf.Len(), 64*int(totalBlockTxCount))
 
 	result := buf.Bytes()
 	sbt.txSigs = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxSigsRS(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// v field is not set
 	for i := 0; i < int(totalBlockTxCount); i++ {
-		assert.Equal(t, txSigs[i].r, sbt.txSigs[i].r)
-		assert.Equal(t, txSigs[i].s, sbt.txSigs[i].s)
+		require.Equal(t, txSigs[i].r, sbt.txSigs[i].r)
+		require.Equal(t, txSigs[i].s, sbt.txSigs[i].s)
 	}
 }
 
@@ -153,16 +153,16 @@ func TestSpanBatchTxsTxNonces(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxNonces(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	sbt.txNonces = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxNonces(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, txNonces, sbt.txNonces)
+	require.Equal(t, txNonces, sbt.txNonces)
 }
 
 func TestSpanBatchTxsTxGases(t *testing.T) {
@@ -179,16 +179,16 @@ func TestSpanBatchTxsTxGases(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxGases(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	sbt.txGases = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxGases(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, txGases, sbt.txGases)
+	require.Equal(t, txGases, sbt.txGases)
 }
 
 func TestSpanBatchTxsTxTos(t *testing.T) {
@@ -208,19 +208,19 @@ func TestSpanBatchTxsTxTos(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxTos(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// to field is fixed length: 20 bytes
-	assert.Equal(t, buf.Len(), 20*len(txTos))
+	require.Equal(t, buf.Len(), 20*len(txTos))
 
 	result := buf.Bytes()
 	sbt.txTos = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxTos(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, txTos, sbt.txTos)
+	require.Equal(t, txTos, sbt.txTos)
 }
 
 func TestSpanBatchTxsTxDatas(t *testing.T) {
@@ -239,7 +239,7 @@ func TestSpanBatchTxsTxDatas(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxDatas(&buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result := buf.Bytes()
 	sbt.txDatas = nil
@@ -247,10 +247,10 @@ func TestSpanBatchTxsTxDatas(t *testing.T) {
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxDatas(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, txDatas, sbt.txDatas)
-	assert.Equal(t, txTypes, sbt.txTypes)
+	require.Equal(t, txDatas, sbt.txDatas)
+	require.Equal(t, txTypes, sbt.txTypes)
 }
 
 func TestSpanBatchTxsRecoverV(t *testing.T) {
@@ -290,7 +290,7 @@ func TestSpanBatchTxsRecoverV(t *testing.T) {
 		recoveredVs = append(recoveredVs, txSig.v)
 	}
 
-	assert.Equal(t, originalVs, recoveredVs, "recovered v mismatch")
+	require.Equal(t, originalVs, recoveredVs, "recovered v mismatch")
 }
 
 func TestSpanBatchTxsRoundTrip(t *testing.T) {
@@ -304,7 +304,7 @@ func TestSpanBatchTxsRoundTrip(t *testing.T) {
 
 		var buf bytes.Buffer
 		err := sbt.encode(&buf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		result := buf.Bytes()
 		r := bytes.NewReader(result)
@@ -312,10 +312,10 @@ func TestSpanBatchTxsRoundTrip(t *testing.T) {
 		var sbt2 spanBatchTxs
 		sbt2.totalBlockTxCount = totalBlockTxCount
 		err = sbt2.decode(r)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sbt2.recoverV(chainID)
 
-		assert.Equal(t, sbt, &sbt2)
+		require.Equal(t, sbt, &sbt2)
 	}
 }
 
@@ -330,16 +330,16 @@ func TestSpanBatchTxsRoundTripFullTxs(t *testing.T) {
 		for i := 0; i < int(totalblockTxCounts); i++ {
 			tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
 			rawTx, err := tx.MarshalBinary()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			txs = append(txs, rawTx)
 		}
 		sbt, err := newSpanBatchTxs(txs, chainID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		txs2, err := sbt.fullTxs(chainID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.Equal(t, txs, txs2)
+		require.Equal(t, txs, txs2)
 	}
 }
 
@@ -372,17 +372,17 @@ func TestSpanBatchTxsFullTxNotEnoughTxTos(t *testing.T) {
 	for i := 0; i < int(totalblockTxCounts); i++ {
 		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
 		rawTx, err := tx.MarshalBinary()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		txs = append(txs, rawTx)
 	}
 	sbt, err := newSpanBatchTxs(txs, chainID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// drop single to field
 	sbt.txTos = sbt.txTos[:len(sbt.txTos)-2]
 
 	_, err = sbt.fullTxs(chainID)
-	assert.EqualError(t, err, "tx to not enough")
+	require.EqualError(t, err, "tx to not enough")
 }
 
 func TestSpanBatchTxsMaxContractCreationBitsLength(t *testing.T) {
@@ -391,7 +391,7 @@ func TestSpanBatchTxsMaxContractCreationBitsLength(t *testing.T) {
 
 	r := bytes.NewReader([]byte{})
 	err := sbt.decodeContractCreationBits(r)
-	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
 }
 
 func TestSpanBatchTxsMaxYParityBitsLength(t *testing.T) {
@@ -400,5 +400,5 @@ func TestSpanBatchTxsMaxYParityBitsLength(t *testing.T) {
 
 	r := bytes.NewReader([]byte{})
 	err := sb.decodeOriginBits(r)
-	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
 }

--- a/op-node/testutils/random.go
+++ b/op-node/testutils/random.go
@@ -141,54 +141,82 @@ func RandomTo(rng *rand.Rand) *common.Address {
 }
 
 func RandomTx(rng *rand.Rand, baseFee *big.Int, signer types.Signer) *types.Transaction {
-	gas := params.TxGas + uint64(rng.Int63n(2_000_000))
-	key := InsecureRandomKey(rng)
-	tip := big.NewInt(rng.Int63n(10 * params.GWei))
-
 	txTypeList := []int{types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType}
 	txType := txTypeList[rng.Intn(len(txTypeList))]
-	var txData types.TxData
+	var tx *types.Transaction
 	switch txType {
 	case types.LegacyTxType:
-		txData = &types.LegacyTx{
-			Nonce:    rng.Uint64(),
-			GasPrice: new(big.Int).SetUint64(rng.Uint64()),
-			Gas:      gas,
-			To:       RandomTo(rng),
-			Value:    RandomETH(rng, 10),
-			Data:     RandomData(rng, rng.Intn(1000)),
-		}
+		tx = RandomLegacyTx(rng, signer)
 	case types.AccessListTxType:
-		txData = &types.AccessListTx{
-			ChainID:    signer.ChainID(),
-			Nonce:      rng.Uint64(),
-			GasPrice:   new(big.Int).SetUint64(rng.Uint64()),
-			Gas:        gas,
-			To:         RandomTo(rng),
-			Value:      RandomETH(rng, 10),
-			Data:       RandomData(rng, rng.Intn(1000)),
-			AccessList: nil,
-		}
+		tx = RandomAccessListTx(rng, signer)
 	case types.DynamicFeeTxType:
-		txData = &types.DynamicFeeTx{
-			ChainID:    signer.ChainID(),
-			Nonce:      rng.Uint64(),
-			GasTipCap:  tip,
-			GasFeeCap:  new(big.Int).Add(baseFee, tip),
-			Gas:        gas,
-			To:         RandomTo(rng),
-			Value:      RandomETH(rng, 10),
-			Data:       RandomData(rng, rng.Intn(1000)),
-			AccessList: nil,
-		}
+		tx = RandomDynamicFeeTxWithBaseFee(rng, baseFee, signer)
 	default:
 		panic("invalid tx type")
+	}
+	return tx
+}
+
+func RandomLegacyTx(rng *rand.Rand, signer types.Signer) *types.Transaction {
+	key := InsecureRandomKey(rng)
+	txData := &types.LegacyTx{
+		Nonce:    rng.Uint64(),
+		GasPrice: new(big.Int).SetUint64(rng.Uint64()),
+		Gas:      params.TxGas + uint64(rng.Int63n(2_000_000)),
+		To:       RandomTo(rng),
+		Value:    RandomETH(rng, 10),
+		Data:     RandomData(rng, rng.Intn(1000)),
 	}
 	tx, err := types.SignNewTx(key, signer, txData)
 	if err != nil {
 		panic(err)
 	}
 	return tx
+}
+
+func RandomAccessListTx(rng *rand.Rand, signer types.Signer) *types.Transaction {
+	key := InsecureRandomKey(rng)
+	txData := &types.AccessListTx{
+		ChainID:    signer.ChainID(),
+		Nonce:      rng.Uint64(),
+		GasPrice:   new(big.Int).SetUint64(rng.Uint64()),
+		Gas:        params.TxGas + uint64(rng.Int63n(2_000_000)),
+		To:         RandomTo(rng),
+		Value:      RandomETH(rng, 10),
+		Data:       RandomData(rng, rng.Intn(1000)),
+		AccessList: nil,
+	}
+	tx, err := types.SignNewTx(key, signer, txData)
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+func RandomDynamicFeeTxWithBaseFee(rng *rand.Rand, baseFee *big.Int, signer types.Signer) *types.Transaction {
+	key := InsecureRandomKey(rng)
+	tip := big.NewInt(rng.Int63n(10 * params.GWei))
+	txData := &types.DynamicFeeTx{
+		ChainID:    signer.ChainID(),
+		Nonce:      rng.Uint64(),
+		GasTipCap:  tip,
+		GasFeeCap:  new(big.Int).Add(baseFee, tip),
+		Gas:        params.TxGas + uint64(rng.Int63n(2_000_000)),
+		To:         RandomTo(rng),
+		Value:      RandomETH(rng, 10),
+		Data:       RandomData(rng, rng.Intn(1000)),
+		AccessList: nil,
+	}
+	tx, err := types.SignNewTx(key, signer, txData)
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+func RandomDynamicFeeTx(rng *rand.Rand, signer types.Signer) *types.Transaction {
+	baseFee := new(big.Int).SetUint64(rng.Uint64())
+	return RandomDynamicFeeTxWithBaseFee(rng, baseFee, signer)
 }
 
 func RandomReceipt(rng *rand.Rand, signer types.Signer, tx *types.Transaction, txIndex uint64, cumulativeGasUsed uint64) *types.Receipt {


### PR DESCRIPTION
Apply https://github.com/ethereum-optimism/optimism/pull/7288#discussion_r1337824793, using geth's `types.Transaction` style.

Apply https://github.com/ethereum-optimism/optimism/pull/7288#issuecomment-1756153736 as well.

> Follow-ups to implement in later PR:
> 
> * `spanBatchTxs` has unused `EncodeRLP` and `DecodeRLP`. The marshal/unmarshal-binary functions are enough.
> * Some encoding/decoding tests in `span_batch_tx_test.go` randomize the test data and assert
>   if the tx types all occurred at the end. Instead, we can make sub-tests with `t.Run()` for each tx-type,
>   and randomize the same amount of txs per type.
> * The `BatchData` wrapper around the typed batch shouldn't have an explicit byte field for the type:
>   it can already be inferred from the contained batch data. See `types.Transaction` in geth as example.
> * `decodeTyped` can be simplified, and the switch-statement should have be more consistent (not mix constants and `data[0]`)
> * `SingularBatchType = iota` is neat, but being explict about protocol constants is better. `iota` is only really meant for internal enumerations that you can flexibly add/remove to.
> * Review usage of `require` vs `assert` in batch tests
> * `parentCheck   []byte` and `l1OriginCheck []byte` should be `[20]byte` types
> 
> And opened #7615 to fix a blocking issue: we must not allow span-batches to be decoded successfully before the HF, or we diverge from the actual mainnet specs.

