### PR TITLE
span-batches: encode bitlists as big-endian integers, use standard Go…

### DIFF
--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -41,7 +41,7 @@ type spanBatchPrefix struct {
 
 type spanBatchPayload struct {
 	blockCount    uint64        // Number of L2 block in the span
-	originBits    *big.Int      // Bitlist of blockCount bits. Each bit indicates if the L1 origin is changed at the L2 block.
+	originBits    *big.Int      // Standard span-batch bitlist of blockCount bits. Each bit indicates if the L1 origin is changed at the L2 block.
 	blockTxCounts []uint64      // List of transaction counts for each L2 block
 	txs           *spanBatchTxs // Transactions encoded in SpanBatch specs
 }
@@ -58,34 +58,12 @@ func (b *RawSpanBatch) GetBatchType() int {
 }
 
 // decodeOriginBits parses data into bp.originBits
-// originBits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
-	originBitBufferLen := bp.blockCount / 8
-	if bp.blockCount%8 != 0 {
-		originBitBufferLen++
-	}
-	// avoid out of memory before allocation
-	if originBitBufferLen > MaxSpanBatchSize {
-		return ErrTooBigSpanBatchSize
-	}
-	originBitBuffer := make([]byte, originBitBufferLen)
-	_, err := io.ReadFull(r, originBitBuffer)
+	bits, err := decodeSpanBatchBits(r, bp.blockCount)
 	if err != nil {
-		return fmt.Errorf("failed to read origin bits: %w", err)
+		return fmt.Errorf("failed to decode origin bits: %w", err)
 	}
-	originBits := new(big.Int)
-	for i := 0; i < int(bp.blockCount); i += 8 {
-		end := i + 8
-		if end > int(bp.blockCount) {
-			end = int(bp.blockCount)
-		}
-		bits := originBitBuffer[i/8]
-		for j := i; j < end; j++ {
-			bit := uint((bits >> (j - i)) & 1)
-			originBits.SetBit(originBits, j, bit)
-		}
-	}
-	bp.originBits = originBits
+	bp.originBits = bits
 	return nil
 }
 
@@ -293,26 +271,9 @@ func (bp *spanBatchPrefix) encodePrefix(w io.Writer) error {
 }
 
 // encodeOriginBits encodes bp.originBits
-// originBits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) encodeOriginBits(w io.Writer) error {
-	originBitBufferLen := bp.blockCount / 8
-	if bp.blockCount%8 != 0 {
-		originBitBufferLen++
-	}
-	originBitBuffer := make([]byte, originBitBufferLen)
-	for i := 0; i < int(bp.blockCount); i += 8 {
-		end := i + 8
-		if end > int(bp.blockCount) {
-			end = int(bp.blockCount)
-		}
-		var bits uint = 0
-		for j := i; j < end; j++ {
-			bits |= bp.originBits.Bit(j) << (j - i)
-		}
-		originBitBuffer[i/8] = byte(bits)
-	}
-	if _, err := w.Write(originBitBuffer); err != nil {
-		return fmt.Errorf("cannot write origin bits: %w", err)
+	if err := encodeSpanBatchBits(w, bp.blockCount, bp.originBits); err != nil {
+		return fmt.Errorf("failed to encode origin bits: %w", err)
 	}
 	return nil
 }

--- a/op-node/rollup/derive/span_batch_util.go
+++ b/op-node/rollup/derive/span_batch_util.go
@@ -1,0 +1,60 @@
+package derive
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/big"
+)
+
+// decodeSpanBatchBits decodes a standard span-batch bitlist.
+// The bitlist is encoded as big-endian integer, left-padded with zeroes to a multiple of 8 bits.
+// The encoded bitlist cannot be longer than MaxSpanBatchSize.
+func decodeSpanBatchBits(r *bytes.Reader, bitLength uint64) (*big.Int, error) {
+	// Round up, ensure enough bytes when number of bits is not a multiple of 8.
+	// Alternative of (L+7)/8 is not overflow-safe.
+	bufLen := bitLength / 8
+	if bitLength%8 != 0 {
+		bufLen++
+	}
+	// avoid out of memory before allocation
+	if bufLen > MaxSpanBatchSize {
+		return nil, ErrTooBigSpanBatchSize
+	}
+	buf := make([]byte, bufLen)
+	_, err := io.ReadFull(r, buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bits: %w", err)
+	}
+	out := new(big.Int)
+	out.SetBytes(buf)
+	// We read the correct number of bytes, but there may still be trailing bits
+	if l := uint64(out.BitLen()); l > bitLength {
+		return nil, fmt.Errorf("bitfield has %d bits, but expected no more than %d", l, bitLength)
+	}
+	return out, nil
+}
+
+// encodeSpanBatchBits encodes a standard span-batch bitlist.
+// The bitlist is encoded as big-endian integer, left-padded with zeroes to a multiple of 8 bits.
+// The encoded bitlist cannot be longer than MaxSpanBatchSize.
+func encodeSpanBatchBits(w io.Writer, bitLength uint64, bits *big.Int) error {
+	if l := uint64(bits.BitLen()); l > bitLength {
+		return fmt.Errorf("bitfield is larger than bitLength: %d > %d", l, bitLength)
+	}
+	// Round up, ensure enough bytes when number of bits is not a multiple of 8.
+	// Alternative of (L+7)/8 is not overflow-safe.
+	bufLen := bitLength / 8
+	if bitLength%8 != 0 { // rounding up this way is safe against overflows
+		bufLen++
+	}
+	if bufLen > MaxSpanBatchSize {
+		return ErrTooBigSpanBatchSize
+	}
+	buf := make([]byte, bufLen)
+	bits.FillBytes(buf) // zero-extended, big-endian
+	if _, err := w.Write(buf); err != nil {
+		return fmt.Errorf("cannot write bits: %w", err)
+	}
+	return nil
+}

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -86,6 +86,9 @@ Notation:
 
 [protobuf spec]: https://protobuf.dev/programming-guides/encoding/#varints
 
+Standard bitlists, in the context of span-batches, are encoded as big-endian integers,
+left-padded with zeroes to the next multiple of 8 bits.
+
 Where:
 
 - `prefix = rel_timestamp ++ l1_origin_num ++ parent_check ++ l1_origin_check`
@@ -98,15 +101,15 @@ Where:
     The hash is truncated to 20 bytes for efficiency, i.e. `span_end.l1_origin.hash[:20]`.
 - `payload = block_count ++ origin_bits ++ block_tx_counts ++ txs`:
   - `block_count`: `uvarint` number of L2 blocks. This is at least 1, empty span batches are invalid.
-  - `origin_bits`: bitlist of `block_count` bits, right-padded to a multiple of 8 bits:
+  - `origin_bits`: standard bitlist of `block_count` bits:
     1 bit per L2 block, indicating if the L1 origin changed this L2 block.
   - `block_tx_counts`: for each block, a `uvarint` of `len(block.transactions)`.
   - `txs`: L2 transactions which is reorganized and encoded as below.
 - `txs = contract_creation_bits ++ y_parity_bits ++
         tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases ++ protected_bits`
-  - `contract_creation_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits,
+  - `contract_creation_bits`: standard bitlist of `sum(block_tx_counts)` bits:
     1 bit per L2 transactions, indicating if transaction is a contract creation transaction.
-  - `y_parity_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits,
+  - `y_parity_bits`: standard bitlist of `sum(block_tx_counts)` bits:
     1 bit per L2 transactions, indicating the y parity value when recovering transaction sender address.
   - `tx_sigs`: concatenated list of transaction signatures
     - `r` is encoded as big-endian `uint256`
@@ -122,7 +125,7 @@ Where:
     - `legacy`: `gasLimit`
     - `1`: ([EIP-2930]): `gasLimit`
     - `2`: ([EIP-1559]): `gas_limit`
-  - `protected_bits`: bit list of length of number of legacy transactions, right-padded to a multiple of 8 bits,
+  - `protected_bits`: standard bitlist of length of number of legacy transactions:
     1 bit per L2 legacy transactions, indicating if transacion is protected([EIP-155]) or not.
 
 Introduce version `2` to the [batch-format](./derivation.md#batch-format) table:


### PR DESCRIPTION
**Description**

This adds a commit on top of the protected tx patch, to:
- simplify the bitlist encoding/decoding code
- deduplicate bitlist handling

This updates the spec to encode the bitlist as big-endian integer, rather than the old right-padded approach. This is a breaking change, but allows us to use the `big.Int` standard encoding/decoding.

**Tests**

Bitlist encoding/decoding is already covered for each usage of a bit-list.

